### PR TITLE
Add Trello Social Auto Publisher plugin skeleton

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/index.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.

--- a/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
+++ b/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Plugin Name: Trello Social Auto Publisher
+ * Plugin URI:  https://example.com/
+ * Description: Automatically publishes posts to Trello.
+ * Version:     1.0.0
+ * Author:      FP-Social-Auto-Publisher
+ * Author URI:  https://example.com/
+ * Text Domain: trello-social-auto-publisher
+ *
+ * @package TrelloSocialAutoPublisher
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+// Define plugin directory.
+if ( ! defined( 'TSAP_PLUGIN_DIR' ) ) {
+    define( 'TSAP_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+}
+
+// Load support files from the includes directory.
+foreach ( glob( TSAP_PLUGIN_DIR . 'includes/*.php' ) as $file ) {
+    require_once $file;
+}


### PR DESCRIPTION
## Summary
- add Trello Social Auto Publisher plugin file with WordPress header and includes loader
- add includes directory with placeholder index file

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68bfdac57b2c832f8e3af44ecc70446a