### PR TITLE
Add social post custom post type class

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Custom post type for Trello Social Auto Publisher.
+ *
+ * @package TrelloSocialAutoPublisher
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Registers the custom post type used by the plugin.
+ */
+class TTS_CPT {
+
+    /**
+     * Initialize hooks.
+     */
+    public function __construct() {
+        add_action( 'init', array( $this, 'register_post_type' ) );
+    }
+
+    /**
+     * Register the custom post type.
+     */
+    public function register_post_type() {
+        $args = array(
+            'public'       => true,
+            'supports'     => array( 'title', 'editor', 'custom-fields', 'thumbnail' ),
+            'show_in_rest' => true,
+            'label'        => __( 'Social Posts', 'trello-social-auto-publisher' ),
+        );
+
+        register_post_type( 'tts_social_post', $args );
+    }
+}
+
+new TTS_CPT();


### PR DESCRIPTION
## Summary
- add `TTS_CPT` class to register `tts_social_post` custom post type with title, editor, custom fields and thumbnail support

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php`


------
https://chatgpt.com/codex/tasks/task_e_68bfdba7e2b4832f9970c7d956934ce8