### PR TITLE
Add scheduling metabox for social posts

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
@@ -19,6 +19,8 @@ class TTS_CPT {
      */
     public function __construct() {
         add_action( 'init', array( $this, 'register_post_type' ) );
+        add_action( 'add_meta_boxes_tts_social_post', array( $this, 'add_schedule_metabox' ) );
+        add_action( 'save_post_tts_social_post', array( $this, 'save_schedule_metabox' ), 5, 3 );
     }
 
     /**
@@ -33,6 +35,55 @@ class TTS_CPT {
         );
 
         register_post_type( 'tts_social_post', $args );
+    }
+
+    /**
+     * Register the scheduling meta box.
+     */
+    public function add_schedule_metabox() {
+        add_meta_box(
+            'tts_programmazione',
+            __( 'Programmazione', 'trello-social-auto-publisher' ),
+            array( $this, 'render_schedule_metabox' ),
+            'tts_social_post',
+            'side'
+        );
+    }
+
+    /**
+     * Render the scheduling meta box.
+     *
+     * @param WP_Post $post Current post object.
+     */
+    public function render_schedule_metabox( $post ) {
+        wp_nonce_field( 'tts_schedule_metabox', 'tts_schedule_nonce' );
+        $value     = get_post_meta( $post->ID, '_tts_publish_at', true );
+        $formatted = $value ? date( 'Y-m-d\\TH:i', strtotime( $value ) ) : '';
+        echo '<input type="datetime-local" name="_tts_publish_at" value="' . esc_attr( $formatted ) . '" class="widefat" />';
+    }
+
+    /**
+     * Save scheduling meta box data.
+     *
+     * @param int     $post_id Post ID.
+     * @param WP_Post $post    Post object.
+     * @param bool    $update  Whether this is an existing post being updated.
+     */
+    public function save_schedule_metabox( $post_id, $post, $update ) {
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+        if ( ! isset( $_POST['tts_schedule_nonce'] ) || ! wp_verify_nonce( $_POST['tts_schedule_nonce'], 'tts_schedule_metabox' ) ) {
+            return;
+        }
+        if ( ! current_user_can( 'edit_post', $post_id ) ) {
+            return;
+        }
+        if ( isset( $_POST['_tts_publish_at'] ) && '' !== $_POST['_tts_publish_at'] ) {
+            update_post_meta( $post_id, '_tts_publish_at', sanitize_text_field( $_POST['_tts_publish_at'] ) );
+        } else {
+            delete_post_meta( $post_id, '_tts_publish_at' );
+        }
     }
 }
 

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
@@ -34,15 +34,14 @@ class TTS_Scheduler {
             return;
         }
 
-        $publish_at = get_post_meta( $post_id, '_tts_publish_at', true );
+        as_unschedule_all_actions( 'tts_publish_social_post', array( 'post_id' => $post_id ) );
+
+        $publish_at = isset( $_POST['_tts_publish_at'] ) ? sanitize_text_field( $_POST['_tts_publish_at'] ) : '';
 
         if ( ! empty( $publish_at ) ) {
-            as_unschedule_all_actions( 'tts_publish_social_post', array( 'post_id' => $post_id ) );
-
             $timestamp = strtotime( $publish_at );
-            if ( $timestamp !== false ) {
-                $action_id = as_schedule_single_action( $timestamp, 'tts_publish_social_post', array( 'post_id' => $post_id ) );
-                update_post_meta( $post_id, '_tts_as_action_id', $action_id );
+            if ( $timestamp ) {
+                as_schedule_single_action( $timestamp, 'tts_publish_social_post', array( 'post_id' => $post_id ) );
             }
         }
     }
@@ -62,7 +61,7 @@ class TTS_Scheduler {
         $log['facebook']  = $this->publish_facebook( $post_id );
         $log['instagram'] = $this->publish_instagram( $post_id );
 
-        update_post_meta( $post_id, '_tts_publish_status', 'published' );
+        update_post_meta( $post_id, '_published_status', 'published' );
         update_post_meta( $post_id, '_tts_publish_log', $log );
     }
 


### PR DESCRIPTION
## Summary
- Add "Programmazione" meta box for `tts_social_post` with datetime field
- Schedule Action Scheduler tasks on save based on `_tts_publish_at`
- Update publish callback to set `_published_status` after posting

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php`


------
https://chatgpt.com/codex/tasks/task_e_68bff1a86f80832fba126077ccd5394c