### PR TITLE
Add client ID support for Trello webhook posts

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
@@ -19,6 +19,7 @@ class TTS_CPT {
      */
     public function __construct() {
         add_action( 'init', array( $this, 'register_post_type' ) );
+        add_action( 'init', array( $this, 'register_meta_fields' ) );
         add_action( 'add_meta_boxes_tts_social_post', array( $this, 'add_schedule_metabox' ) );
         add_action( 'save_post_tts_social_post', array( $this, 'save_schedule_metabox' ), 5, 3 );
     }
@@ -35,6 +36,21 @@ class TTS_CPT {
         );
 
         register_post_type( 'tts_social_post', $args );
+    }
+
+    /**
+     * Register custom meta fields.
+     */
+    public function register_meta_fields() {
+        register_post_meta(
+            'tts_social_post',
+            '_tts_client_id',
+            array(
+                'show_in_rest' => true,
+                'single'       => true,
+                'type'         => 'integer',
+            )
+        );
     }
 
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php
@@ -72,11 +72,57 @@ class TTS_Webhook {
             'attachments' => isset( $card['attachments'] ) ? $card['attachments'] : array(),
             'due'         => isset( $card['due'] ) ? $card['due'] : '',
             'idList'      => isset( $card['idList'] ) ? $card['idList'] : '',
+            'idBoard'     => isset( $card['idBoard'] ) ? $card['idBoard'] : '',
         );
 
         $mapping = isset( $options['column_mapping'] ) ? json_decode( $options['column_mapping'], true ) : array();
         if ( empty( $result['idList'] ) || ! is_array( $mapping ) || ! array_key_exists( $result['idList'], $mapping ) ) {
             return rest_ensure_response( array( 'message' => __( 'Unmapped list.', 'trello-social-auto-publisher' ) ) );
+        }
+
+        $client_id = 0;
+        $board_id  = $result['idBoard'];
+        if ( ! $board_id && isset( $data['action']['data']['board']['id'] ) ) {
+            $board_id = $data['action']['data']['board']['id'];
+        }
+        if ( $board_id ) {
+            $client_query = get_posts(
+                array(
+                    'post_type'   => 'tts_client',
+                    'post_status' => 'any',
+                    'meta_query'  => array(
+                        array(
+                            'key'   => '_tts_trello_board',
+                            'value' => $board_id,
+                        ),
+                    ),
+                    'fields'      => 'ids',
+                    'numberposts' => 1,
+                )
+            );
+            if ( ! empty( $client_query ) ) {
+                $client_id = (int) $client_query[0];
+            }
+        }
+        if ( ! $client_id && $result['idList'] ) {
+            $client_query = get_posts(
+                array(
+                    'post_type'   => 'tts_client',
+                    'post_status' => 'any',
+                    'meta_query'  => array(
+                        array(
+                            'key'     => '_tts_trello_map',
+                            'value'   => $result['idList'],
+                            'compare' => 'LIKE',
+                        ),
+                    ),
+                    'fields'      => 'ids',
+                    'numberposts' => 1,
+                )
+            );
+            if ( ! empty( $client_query ) ) {
+                $client_id = (int) $client_query[0];
+            }
         }
 
         $post_id = wp_insert_post(
@@ -85,6 +131,7 @@ class TTS_Webhook {
                 'post_content' => wp_kses_post( $result['desc'] ),
                 'post_type'    => 'tts_social_post',
                 'post_status'  => 'publish',
+                'meta_input'   => array( '_tts_client_id' => $client_id ),
             ),
             true
         );
@@ -93,7 +140,8 @@ class TTS_Webhook {
             update_post_meta( $post_id, '_trello_labels', $result['labels'] );
             update_post_meta( $post_id, '_trello_attachments', $result['attachments'] );
             update_post_meta( $post_id, '_trello_due', $result['due'] );
-            $result['post_id'] = $post_id;
+            $result['post_id']   = $post_id;
+            $result['client_id'] = $client_id;
         }
 
         return rest_ensure_response( $result );


### PR DESCRIPTION
## Summary
- register `_tts_client_id` meta field on `tts_social_post`
- identify client from Trello board/list in webhook and store client ID when creating posts

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php`


------
https://chatgpt.com/codex/tasks/task_e_68bff7dad6dc832f9b3291497f912915