### PR TITLE
Add logging for social publishing events

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
@@ -59,8 +59,11 @@ class TTS_Scheduler {
 
         $client_id = intval( get_post_meta( $post_id, '_tts_client_id', true ) );
         if ( ! $client_id ) {
+            tts_log_event( $post_id, 'scheduler', 'error', __( 'Missing client ID', 'trello-social-auto-publisher' ), '' );
             return;
         }
+
+        tts_log_event( $post_id, 'scheduler', 'start', __( 'Publishing social post', 'trello-social-auto-publisher' ), '' );
 
         $tokens = array(
             'facebook'  => get_post_meta( $client_id, '_tts_fb_token', true ),
@@ -72,12 +75,14 @@ class TTS_Scheduler {
             $settings = array();
         }
 
-        $log = array();
+        $log              = array();
         $log['facebook']  = $this->publish_facebook( $post_id, $tokens['facebook'], $settings );
         $log['instagram'] = $this->publish_instagram( $post_id, $tokens['instagram'], $settings );
 
         update_post_meta( $post_id, '_published_status', 'published' );
         update_post_meta( $post_id, '_tts_publish_log', $log );
+
+        tts_log_event( $post_id, 'scheduler', 'complete', __( 'Publish process completed', 'trello-social-auto-publisher' ), $log );
     }
 
     /**
@@ -89,7 +94,16 @@ class TTS_Scheduler {
      * @return string Log message.
      */
     protected function publish_facebook( $post_id, $token, $settings ) {
-        return __( 'Published to Facebook', 'trello-social-auto-publisher' );
+        if ( empty( $token ) ) {
+            $message = __( 'Facebook token missing', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'facebook', 'error', $message, '' );
+            return $message;
+        }
+
+        $message = __( 'Published to Facebook', 'trello-social-auto-publisher' );
+        tts_log_event( $post_id, 'facebook', 'success', $message, array() );
+
+        return $message;
     }
 
     /**
@@ -101,7 +115,16 @@ class TTS_Scheduler {
      * @return string Log message.
      */
     protected function publish_instagram( $post_id, $token, $settings ) {
-        return __( 'Published to Instagram', 'trello-social-auto-publisher' );
+        if ( empty( $token ) ) {
+            $message = __( 'Instagram token missing', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'instagram', 'error', $message, '' );
+            return $message;
+        }
+
+        $message = __( 'Published to Instagram', 'trello-social-auto-publisher' );
+        tts_log_event( $post_id, 'instagram', 'success', $message, array() );
+
+        return $message;
     }
 }
 

--- a/wp-content/plugins/trello-social-auto-publisher/includes/tts-logger.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/tts-logger.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Logging utilities for Trello Social Auto Publisher.
+ *
+ * @package TrelloSocialAutoPublisher
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Create the tts logs table.
+ */
+function tts_create_logs_table() {
+    global $wpdb;
+
+    $table_name      = $wpdb->prefix . 'tts_logs';
+    $charset_collate = $wpdb->get_charset_collate();
+
+    $sql = "CREATE TABLE {$table_name} (
+        id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+        post_id bigint(20) unsigned NOT NULL,
+        channel varchar(50) NOT NULL,
+        status varchar(20) NOT NULL,
+        message text NOT NULL,
+        response longtext NULL,
+        created_at datetime NOT NULL,
+        PRIMARY KEY  (id)
+    ) {$charset_collate};";
+
+    require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+    dbDelta( $sql );
+}
+
+/**
+ * Log an event to the custom table.
+ *
+ * @param int    $post_id  Post ID.
+ * @param string $channel  Channel identifier.
+ * @param string $status   Status of the event.
+ * @param string $message  Message to log.
+ * @param mixed  $response Response data.
+ */
+function tts_log_event( $post_id, $channel, $status, $message, $response ) {
+    global $wpdb;
+
+    $table = $wpdb->prefix . 'tts_logs';
+    $wpdb->insert(
+        $table,
+        array(
+            'post_id'   => $post_id,
+            'channel'   => $channel,
+            'status'    => $status,
+            'message'   => $message,
+            'response'  => is_scalar( $response ) ? $response : wp_json_encode( $response ),
+            'created_at'=> current_time( 'mysql' ),
+        ),
+        array( '%d', '%s', '%s', '%s', '%s', '%s' )
+    );
+}

--- a/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
+++ b/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
@@ -35,6 +35,8 @@ if ( ! function_exists( 'as_schedule_single_action' ) ) {
 foreach ( glob( TSAP_PLUGIN_DIR . 'includes/*.php' ) as $file ) {
     require_once $file;
 }
+// Register activation hook.
+register_activation_hook( __FILE__, 'tts_create_logs_table' );
 
 // Load admin files when in the dashboard.
 if ( is_admin() ) {


### PR DESCRIPTION
## Summary
- create `tts_logs` table and helper functions for event logging
- log publish attempts and responses across scheduler and social channels
- hook table creation to plugin activation

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/tts-logger.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php`


------
https://chatgpt.com/codex/tasks/task_e_68c00332bea4832f874587e7320f2a3c