### PR TITLE
Add webhook signature verification using client secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 Questo progetto pubblica automaticamente contenuti sui social a partire da Trello.
 
+## Generazione e configurazione di token e secret
+
+1. Visita la pagina [https://trello.com/app-key](https://trello.com/app-key) e copia la tua **API Key**.
+2. Dalla stessa pagina ottieni il **Secret** (client secret) e genera un **Token** cliccando sul link dedicato.
+3. All'interno dell'editor del post type `tts_client` inserisci Key, Token e Secret nei campi dedicati del metabox *Client Credentials*.
+4. Il Secret viene usato per validare le chiamate webhook. Trello invierà l'header `X-Trello-Webhook` firmato; in alternativa è possibile inviare un parametro `hmac` calcolato con `hash_hmac('sha256', $payload, $secret)`.
+
 ## Mappatura Trello → Canali Social
 
 Nel metabox del custom post type `tts_client` è possibile definire una mappatura tra l'`idList` di Trello e il relativo `canale_social`.

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php
@@ -67,9 +67,10 @@ class TTS_Client {
     public function render_credentials_metabox( $post ) {
         wp_nonce_field( 'tts_client_credentials', 'tts_client_nonce' );
 
-        $trello_key   = get_post_meta( $post->ID, '_tts_trello_key', true );
-        $trello_token = get_post_meta( $post->ID, '_tts_trello_token', true );
-        $board_id     = get_post_meta( $post->ID, '_tts_trello_board', true );
+        $trello_key    = get_post_meta( $post->ID, '_tts_trello_key', true );
+        $trello_token  = get_post_meta( $post->ID, '_tts_trello_token', true );
+        $trello_secret = get_post_meta( $post->ID, '_tts_trello_secret', true );
+        $board_id      = get_post_meta( $post->ID, '_tts_trello_board', true );
         $fb_token     = get_post_meta( $post->ID, '_tts_fb_token', true );
         $ig_token     = get_post_meta( $post->ID, '_tts_ig_token', true );
         $trello_map   = get_post_meta( $post->ID, '_tts_trello_map', true );
@@ -83,6 +84,9 @@ class TTS_Client {
 
         echo '<p><label for="tts_trello_token">' . esc_html__( 'Trello API Token', 'trello-social-auto-publisher' ) . '</label>';
         echo '<input type="text" id="tts_trello_token" name="tts_trello_token" value="' . esc_attr( $trello_token ) . '" class="widefat" /></p>';
+
+        echo '<p><label for="tts_trello_secret">' . esc_html__( 'Trello API Secret', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<input type="text" id="tts_trello_secret" name="tts_trello_secret" value="' . esc_attr( $trello_secret ) . '" class="widefat" /></p>';
 
         echo '<p><label for="tts_trello_board">' . esc_html__( 'Trello Board/List ID', 'trello-social-auto-publisher' ) . '</label>';
         echo '<input type="text" id="tts_trello_board" name="tts_trello_board" value="' . esc_attr( $board_id ) . '" class="widefat" /></p>';
@@ -150,11 +154,12 @@ class TTS_Client {
         }
 
         $fields = array(
-            'tts_trello_key'   => '_tts_trello_key',
-            'tts_trello_token' => '_tts_trello_token',
-            'tts_trello_board' => '_tts_trello_board',
-            'tts_fb_token'     => '_tts_fb_token',
-            'tts_ig_token'     => '_tts_ig_token',
+            'tts_trello_key'    => '_tts_trello_key',
+            'tts_trello_token'  => '_tts_trello_token',
+            'tts_trello_secret' => '_tts_trello_secret',
+            'tts_trello_board'  => '_tts_trello_board',
+            'tts_fb_token'      => '_tts_fb_token',
+            'tts_ig_token'      => '_tts_ig_token',
         );
 
         foreach ( $fields as $field => $meta_key ) {


### PR DESCRIPTION
## Summary
- Store Trello API secret alongside key and token for each client
- Validate webhook requests via `X-Trello-Webhook` header or `hmac` parameter using the stored secret
- Document token/secret generation and configuration in README

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php`


------
https://chatgpt.com/codex/tasks/task_e_68c0085d0934832f869bed6d4628a89b