### PR TITLE
Add publication notifications

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
@@ -89,6 +89,7 @@ class TTS_Scheduler {
                     $publisher   = new $class();
                     $credentials = isset( $tokens[ $ch ] ) ? $tokens[ $ch ] : '';
                     $log[ $ch ]  = $publisher->publish( $post_id, $credentials );
+                    tts_notify_publication( $post_id, 'processed', $ch );
                 }
             }
         }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
@@ -25,11 +25,13 @@ class TTS_Publisher_Facebook {
         if ( empty( $credentials ) ) {
             $message = __( 'Facebook token missing', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'facebook', 'error', $message, '' );
+            tts_notify_publication( $post_id, 'error', 'facebook' );
             return $message;
         }
 
         $message = __( 'Published to Facebook', 'trello-social-auto-publisher' );
         tts_log_event( $post_id, 'facebook', 'success', $message, array() );
+        tts_notify_publication( $post_id, 'success', 'facebook' );
         return $message;
     }
 }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php
@@ -25,11 +25,13 @@ class TTS_Publisher_Instagram {
         if ( empty( $credentials ) ) {
             $message = __( 'Instagram token missing', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'instagram', 'error', $message, '' );
+            tts_notify_publication( $post_id, 'error', 'instagram' );
             return $message;
         }
 
         $message = __( 'Published to Instagram', 'trello-social-auto-publisher' );
         tts_log_event( $post_id, 'instagram', 'success', $message, array() );
+        tts_notify_publication( $post_id, 'success', 'instagram' );
         return $message;
     }
 }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/tts-notify.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/tts-notify.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Notification utilities for Trello Social Auto Publisher.
+ *
+ * @package TrelloSocialAutoPublisher
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Send a notification when a social post is processed.
+ *
+ * Uses a Slack webhook if configured via the `tts_slack_webhook` option,
+ * otherwise falls back to the site's admin email via `wp_mail`.
+ *
+ * @param int    $post_id Post ID.
+ * @param string $status  Publication status.
+ * @param string $channel Social channel.
+ */
+function tts_notify_publication( $post_id, $status, $channel ) {
+    $title   = get_the_title( $post_id );
+    $message = sprintf( 'Post "%s" on %s: %s', $title, $channel, $status );
+
+    $webhook = get_option( 'tts_slack_webhook', '' );
+    if ( ! empty( $webhook ) ) {
+        wp_remote_post(
+            $webhook,
+            array(
+                'headers' => array( 'Content-Type' => 'application/json' ),
+                'body'    => wp_json_encode( array( 'text' => $message ) ),
+            )
+        );
+        return;
+    }
+
+    $subject = sprintf( '[Social Publish] %s - %s', $channel, $status );
+    wp_mail( get_option( 'admin_email' ), $subject, $message );
+}


### PR DESCRIPTION
## Summary
- add `tts_notify_publication` utility for Slack/email notifications
- notify from scheduler callback and Facebook/Instagram publishers when posts are processed

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/tts-notify.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php`


------
https://chatgpt.com/codex/tasks/task_e_68c00e6085c8832fb14f97ea7c0ede9a