### PR TITLE
Add template-driven social previews

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
@@ -21,6 +21,7 @@ class TTS_CPT {
         add_action( 'init', array( $this, 'register_post_type' ) );
         add_action( 'init', array( $this, 'register_meta_fields' ) );
         add_action( 'add_meta_boxes_tts_social_post', array( $this, 'add_schedule_metabox' ) );
+        add_action( 'add_meta_boxes_tts_social_post', array( $this, 'add_preview_metabox' ) );
         add_action( 'save_post_tts_social_post', array( $this, 'save_schedule_metabox' ), 5, 3 );
     }
 
@@ -67,6 +68,19 @@ class TTS_CPT {
     }
 
     /**
+     * Register the preview meta box.
+     */
+    public function add_preview_metabox() {
+        add_meta_box(
+            'tts_anteprima',
+            __( 'Anteprima', 'trello-social-auto-publisher' ),
+            array( $this, 'render_preview_metabox' ),
+            'tts_social_post',
+            'normal'
+        );
+    }
+
+    /**
      * Render the scheduling meta box.
      *
      * @param WP_Post $post Current post object.
@@ -76,6 +90,29 @@ class TTS_CPT {
         $value     = get_post_meta( $post->ID, '_tts_publish_at', true );
         $formatted = $value ? date( 'Y-m-d\\TH:i', strtotime( $value ) ) : '';
         echo '<input type="datetime-local" name="_tts_publish_at" value="' . esc_attr( $formatted ) . '" class="widefat" />';
+    }
+
+    /**
+     * Render the preview meta box.
+     *
+     * @param WP_Post $post Current post object.
+     */
+    public function render_preview_metabox( $post ) {
+        $options   = get_option( 'tts_settings', array() );
+        $templates = array(
+            'facebook'  => isset( $options['facebook_template'] ) ? $options['facebook_template'] : '',
+            'instagram' => isset( $options['instagram_template'] ) ? $options['instagram_template'] : '',
+        );
+
+        echo '<div class="tts-preview">';
+        foreach ( $templates as $network => $template ) {
+            if ( empty( $template ) ) {
+                continue;
+            }
+            $preview = tts_apply_template( $template, $post->ID );
+            echo '<p><strong>' . esc_html( ucfirst( $network ) ) . ':</strong> ' . esc_html( $preview ) . '</p>';
+        }
+        echo '</div>';
     }
 
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
@@ -70,6 +70,8 @@ class TTS_Scheduler {
             'instagram' => get_post_meta( $client_id, '_tts_ig_token', true ),
         );
 
+        $options = get_option( 'tts_settings', array() );
+
         $channel = get_post_meta( $post_id, '_tts_social_channel', true );
         if ( empty( $channel ) ) {
             tts_log_event( $post_id, 'scheduler', 'error', __( 'Missing social channel', 'trello-social-auto-publisher' ), '' );
@@ -88,7 +90,9 @@ class TTS_Scheduler {
                 if ( class_exists( $class ) ) {
                     $publisher   = new $class();
                     $credentials = isset( $tokens[ $ch ] ) ? $tokens[ $ch ] : '';
-                    $log[ $ch ]  = $publisher->publish( $post_id, $credentials );
+                    $template    = isset( $options[ $ch . '_template' ] ) ? $options[ $ch . '_template' ] : '';
+                    $message     = $template ? tts_apply_template( $template, $post_id ) : '';
+                    $log[ $ch ]  = $publisher->publish( $post_id, $credentials, $message );
                     tts_notify_publication( $post_id, 'processed', $ch );
                 }
             }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
@@ -112,6 +112,30 @@ class TTS_Settings {
             'tts_settings',
             'tts_utm_options'
         );
+
+        // Template options.
+        add_settings_section(
+            'tts_template_options',
+            __( 'Template Options', 'trello-social-auto-publisher' ),
+            '__return_false',
+            'tts_settings'
+        );
+
+        add_settings_field(
+            'facebook_template',
+            __( 'Facebook Template', 'trello-social-auto-publisher' ),
+            array( $this, 'render_facebook_template_field' ),
+            'tts_settings',
+            'tts_template_options'
+        );
+
+        add_settings_field(
+            'instagram_template',
+            __( 'Instagram Template', 'trello-social-auto-publisher' ),
+            array( $this, 'render_instagram_template_field' ),
+            'tts_settings',
+            'tts_template_options'
+        );
     }
 
     /**
@@ -175,6 +199,24 @@ class TTS_Settings {
         $options = get_option( 'tts_settings', array() );
         $value   = isset( $options['utm_options'] ) ? esc_attr( $options['utm_options'] ) : '';
         echo '<input type="text" name="tts_settings[utm_options]" value="' . $value . '" class="regular-text" placeholder="utm_source=...&utm_medium=..." />';
+    }
+
+    /**
+     * Render field for Facebook template.
+     */
+    public function render_facebook_template_field() {
+        $options = get_option( 'tts_settings', array() );
+        $value   = isset( $options['facebook_template'] ) ? esc_attr( $options['facebook_template'] ) : '';
+        echo '<input type="text" name="tts_settings[facebook_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url}" />';
+    }
+
+    /**
+     * Render field for Instagram template.
+     */
+    public function render_instagram_template_field() {
+        $options = get_option( 'tts_settings', array() );
+        $value   = isset( $options['instagram_template'] ) ? esc_attr( $options['instagram_template'] ) : '';
+        echo '<input type="text" name="tts_settings[instagram_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url}" />';
     }
 }
 

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
@@ -17,11 +17,12 @@ class TTS_Publisher_Facebook {
     /**
      * Publish the post to Facebook.
      *
-     * @param int   $post_id     Post ID.
-     * @param mixed $credentials Credentials used for publishing.
+     * @param int    $post_id     Post ID.
+     * @param mixed  $credentials Credentials used for publishing.
+     * @param string $message     Message to publish.
      * @return string Log message.
      */
-    public function publish( $post_id, $credentials ) {
+    public function publish( $post_id, $credentials, $message ) {
         if ( empty( $credentials ) ) {
             $message = __( 'Facebook token missing', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'facebook', 'error', $message, '' );
@@ -29,9 +30,9 @@ class TTS_Publisher_Facebook {
             return $message;
         }
 
-        $message = __( 'Published to Facebook', 'trello-social-auto-publisher' );
-        tts_log_event( $post_id, 'facebook', 'success', $message, array() );
+        $response = __( 'Published to Facebook', 'trello-social-auto-publisher' );
+        tts_log_event( $post_id, 'facebook', 'success', $response, array( 'message' => $message ) );
         tts_notify_publication( $post_id, 'success', 'facebook' );
-        return $message;
+        return $response;
     }
 }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php
@@ -17,11 +17,12 @@ class TTS_Publisher_Instagram {
     /**
      * Publish the post to Instagram.
      *
-     * @param int   $post_id     Post ID.
-     * @param mixed $credentials Credentials used for publishing.
+     * @param int    $post_id     Post ID.
+     * @param mixed  $credentials Credentials used for publishing.
+     * @param string $message     Message to publish.
      * @return string Log message.
      */
-    public function publish( $post_id, $credentials ) {
+    public function publish( $post_id, $credentials, $message ) {
         if ( empty( $credentials ) ) {
             $message = __( 'Instagram token missing', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'instagram', 'error', $message, '' );
@@ -29,9 +30,9 @@ class TTS_Publisher_Instagram {
             return $message;
         }
 
-        $message = __( 'Published to Instagram', 'trello-social-auto-publisher' );
-        tts_log_event( $post_id, 'instagram', 'success', $message, array() );
+        $response = __( 'Published to Instagram', 'trello-social-auto-publisher' );
+        tts_log_event( $post_id, 'instagram', 'success', $response, array( 'message' => $message ) );
         tts_notify_publication( $post_id, 'success', 'instagram' );
-        return $message;
+        return $response;
     }
 }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/tts-template.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/tts-template.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Template utilities for Trello Social Auto Publisher.
+ *
+ * @package TrelloSocialAutoPublisher
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Apply placeholders in template.
+ *
+ * @param string $template Template string.
+ * @param int    $post_id  Post ID.
+ * @return string Processed template.
+ */
+function tts_apply_template( $template, $post_id ) {
+    $post = get_post( $post_id );
+    if ( ! $post ) {
+        return $template;
+    }
+
+    $options = get_option( 'tts_settings', array() );
+    $url     = get_permalink( $post_id );
+    $utm     = isset( $options['utm_options'] ) ? ltrim( $options['utm_options'], '?' ) : '';
+    if ( $utm ) {
+        $url .= ( strpos( $url, '?' ) === false ? '?' : '&' ) . $utm;
+    }
+
+    $replacements = array(
+        '{title}' => get_the_title( $post_id ),
+        '{url}'   => $url,
+    );
+
+    return strtr( $template, $replacements );
+}


### PR DESCRIPTION
## Summary
- add settings fields for Facebook and Instagram templates
- show placeholder-based template previews in Social Post editor
- apply templates when publishing to social channels

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/tts-template.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php`


------
https://chatgpt.com/codex/tasks/task_e_68c00f643428832fa7eb8c1f2b824afb