### PR TITLE
Add per-channel UTM controls and apply them on publish

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
@@ -109,7 +109,7 @@ class TTS_CPT {
             if ( empty( $template ) ) {
                 continue;
             }
-            $preview = tts_apply_template( $template, $post->ID );
+            $preview = tts_apply_template( $template, $post->ID, $network );
             echo '<p><strong>' . esc_html( ucfirst( $network ) ) . ':</strong> ' . esc_html( $preview ) . '</p>';
         }
         echo '</div>';

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
@@ -91,7 +91,7 @@ class TTS_Scheduler {
                     $publisher   = new $class();
                     $credentials = isset( $tokens[ $ch ] ) ? $tokens[ $ch ] : '';
                     $template    = isset( $options[ $ch . '_template' ] ) ? $options[ $ch . '_template' ] : '';
-                    $message     = $template ? tts_apply_template( $template, $post_id ) : '';
+                    $message     = $template ? tts_apply_template( $template, $post_id, $ch ) : '';
                     $log[ $ch ]  = $publisher->publish( $post_id, $credentials, $message );
                     tts_notify_publication( $post_id, 'processed', $ch );
                 }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
@@ -104,14 +104,24 @@ class TTS_Settings {
             '__return_false',
             'tts_settings'
         );
+        $channels = array( 'facebook', 'instagram' );
+        $params   = array( 'source', 'medium', 'campaign' );
 
-        add_settings_field(
-            'utm_options',
-            __( 'UTM Parameters (query string)', 'trello-social-auto-publisher' ),
-            array( $this, 'render_utm_options_field' ),
-            'tts_settings',
-            'tts_utm_options'
-        );
+        foreach ( $channels as $channel ) {
+            foreach ( $params as $param ) {
+                add_settings_field(
+                    $channel . '_utm_' . $param,
+                    sprintf( __( '%s UTM %s', 'trello-social-auto-publisher' ), ucfirst( $channel ), ucfirst( $param ) ),
+                    array( $this, 'render_utm_field' ),
+                    'tts_settings',
+                    'tts_utm_options',
+                    array(
+                        'channel' => $channel,
+                        'param'   => $param,
+                    )
+                );
+            }
+        }
 
         // Template options.
         add_settings_section(
@@ -193,12 +203,17 @@ class TTS_Settings {
     }
 
     /**
-     * Render field for UTM options.
+     * Render a UTM field for a given channel and parameter.
+     *
+     * @param array $args Field arguments.
      */
-    public function render_utm_options_field() {
+    public function render_utm_field( $args ) {
         $options = get_option( 'tts_settings', array() );
-        $value   = isset( $options['utm_options'] ) ? esc_attr( $options['utm_options'] ) : '';
-        echo '<input type="text" name="tts_settings[utm_options]" value="' . $value . '" class="regular-text" placeholder="utm_source=...&utm_medium=..." />';
+        $channel = isset( $args['channel'] ) ? $args['channel'] : '';
+        $param   = isset( $args['param'] ) ? $args['param'] : '';
+        $key     = $channel . '_utm_' . $param;
+        $value   = isset( $options[ $key ] ) ? esc_attr( $options[ $key ] ) : '';
+        echo '<input type="text" name="tts_settings[' . esc_attr( $key ) . ']" value="' . $value . '" class="regular-text" />';
     }
 
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/includes/tts-template.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/tts-template.php
@@ -10,24 +10,46 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Build a URL with UTM parameters for a specific channel.
+ *
+ * @param string $url     Base URL.
+ * @param string $channel Channel name.
+ * @return string URL with UTM parameters.
+ */
+function tts_build_utm_url( $url, $channel ) {
+    $options = get_option( 'tts_settings', array() );
+    $params  = array();
+
+    foreach ( array( 'source', 'medium', 'campaign' ) as $param ) {
+        $key = $channel . '_utm_' . $param;
+        if ( ! empty( $options[ $key ] ) ) {
+            $params[ 'utm_' . $param ] = $options[ $key ];
+        }
+    }
+
+    if ( empty( $params ) ) {
+        return $url;
+    }
+
+    return add_query_arg( $params, $url );
+}
+
+/**
  * Apply placeholders in template.
  *
  * @param string $template Template string.
  * @param int    $post_id  Post ID.
+ * @param string $channel  Channel name.
  * @return string Processed template.
  */
-function tts_apply_template( $template, $post_id ) {
+function tts_apply_template( $template, $post_id, $channel ) {
     $post = get_post( $post_id );
     if ( ! $post ) {
         return $template;
     }
 
-    $options = get_option( 'tts_settings', array() );
-    $url     = get_permalink( $post_id );
-    $utm     = isset( $options['utm_options'] ) ? ltrim( $options['utm_options'], '?' ) : '';
-    if ( $utm ) {
-        $url .= ( strpos( $url, '?' ) === false ? '?' : '&' ) . $utm;
-    }
+    $url = get_permalink( $post_id );
+    $url = tts_build_utm_url( $url, $channel );
 
     $replacements = array(
         '{title}' => get_the_title( $post_id ),


### PR DESCRIPTION
## Summary
- allow specifying UTM source/medium/campaign for Facebook and Instagram
- build channel-specific UTM URLs and apply them before publishing

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/tts-template.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php`


------
https://chatgpt.com/codex/tasks/task_e_68c011319ac0832fac3943bfdcd0c804