### PR TITLE
Add React dashboard for social posts

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -21,6 +21,7 @@ class TTS_Admin {
         add_action( 'admin_menu', array( $this, 'register_menu' ) );
         add_action( 'restrict_manage_posts', array( $this, 'add_client_filter' ) );
         add_action( 'pre_get_posts', array( $this, 'filter_posts_by_client' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_dashboard_assets' ) );
     }
 
     /**
@@ -44,6 +45,44 @@ class TTS_Admin {
             array( $this, 'render_social_posts_page' ),
             'dashicons-share'
         );
+
+        add_menu_page(
+            __( 'Social Dashboard', 'trello-social-auto-publisher' ),
+            __( 'Social Dashboard', 'trello-social-auto-publisher' ),
+            'manage_options',
+            'tts-dashboard',
+            array( $this, 'render_dashboard_page' ),
+            'dashicons-chart-bar'
+        );
+    }
+
+    /**
+     * Enqueue assets for the dashboard page.
+     *
+     * @param string $hook Current admin page hook.
+     */
+    public function enqueue_dashboard_assets( $hook ) {
+        if ( 'toplevel_page_tts-dashboard' !== $hook ) {
+            return;
+        }
+
+        wp_enqueue_script(
+            'tts-dashboard',
+            plugin_dir_url( __FILE__ ) . 'js/tts-dashboard.js',
+            array( 'wp-element', 'wp-components', 'wp-api-fetch' ),
+            '1.0',
+            true
+        );
+    }
+
+    /**
+     * Render the dashboard page.
+     */
+    public function render_dashboard_page() {
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'Social Dashboard', 'trello-social-auto-publisher' ) . '</h1>';
+        echo '<div id="tts-dashboard-root"></div>';
+        echo '</div>';
     }
 
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-dashboard.js
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-dashboard.js
@@ -1,0 +1,94 @@
+const { createElement, render, useState, useEffect } = wp.element;
+const { SelectControl, Spinner } = wp.components;
+const apiFetch = wp.apiFetch;
+
+const PostList = ( { posts } ) => {
+  return createElement(
+    'table',
+    { className: 'widefat fixed' },
+    [
+      createElement(
+        'thead',
+        {},
+        createElement( 'tr', {}, [
+          createElement( 'th', {}, 'Title' ),
+          createElement( 'th', {}, 'Channel' ),
+          createElement( 'th', {}, 'Status' ),
+          createElement( 'th', {}, 'Log' ),
+        ] )
+      ),
+      createElement(
+        'tbody',
+        {},
+        posts.map( ( post ) => {
+          const channel = post.meta && post.meta._tts_social_channel ? post.meta._tts_social_channel : [];
+          const status = post.meta && post.meta._published_status ? post.meta._published_status : 'scheduled';
+          const channels = Array.isArray( channel ) ? channel.join( ', ' ) : channel;
+          return createElement( 'tr', { key: post.id }, [
+            createElement( 'td', {}, post.title.rendered ),
+            createElement( 'td', {}, channels ),
+            createElement( 'td', {}, status ),
+            createElement( 'td', {},
+              createElement( 'a', { href: `admin.php?page=tts-social-posts&action=log&post=${ post.id }` }, 'View' )
+            )
+          ] );
+        } )
+      )
+    ]
+  );
+};
+
+const Dashboard = () => {
+  const [ posts, setPosts ] = useState( [] );
+  const [ channel, setChannel ] = useState( '' );
+  const [ status, setStatus ] = useState( '' );
+  const [ loading, setLoading ] = useState( true );
+
+  useEffect( () => {
+    apiFetch( { path: '/wp/v2/tts_social_post?per_page=100&_fields=id,title,meta' } )
+      .then( ( data ) => {
+        setPosts( data );
+        setLoading( false );
+      } );
+  }, [] );
+
+  const filtered = posts.filter( ( post ) => {
+    const postChannel = post.meta && post.meta._tts_social_channel ? post.meta._tts_social_channel : [];
+    const postStatus = post.meta && post.meta._published_status ? post.meta._published_status : 'scheduled';
+    const channels = Array.isArray( postChannel ) ? postChannel : [ postChannel ];
+    return ( ! channel || channels.includes( channel ) ) && ( ! status || status === postStatus );
+  } );
+
+  return createElement( 'div', {}, [
+    createElement( 'div', { className: 'tts-filters' }, [
+      createElement( SelectControl, {
+        label: 'Channel',
+        value: channel,
+        options: [
+          { label: 'All', value: '' },
+          { label: 'Facebook', value: 'facebook' },
+          { label: 'Instagram', value: 'instagram' }
+        ],
+        onChange: ( value ) => setChannel( value )
+      } ),
+      createElement( SelectControl, {
+        label: 'Status',
+        value: status,
+        options: [
+          { label: 'All', value: '' },
+          { label: 'scheduled', value: 'scheduled' },
+          { label: 'published', value: 'published' }
+        ],
+        onChange: ( value ) => setStatus( value )
+      } )
+    ] ),
+    loading ? createElement( Spinner, {} ) : createElement( PostList, { posts: filtered } )
+  ] );
+};
+
+document.addEventListener( 'DOMContentLoaded', () => {
+  const root = document.getElementById( 'tts-dashboard-root' );
+  if ( root ) {
+    render( createElement( Dashboard ), root );
+  }
+} );


### PR DESCRIPTION
## Summary
- add React-based dashboard entrypoint fetching social posts via WP REST API
- register Social Dashboard admin page and enqueue dashboard assets

## Testing
- `php -l FP-Social-Auto-Publisher/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php`
- `node --check FP-Social-Auto-Publisher/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-dashboard.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0122fca48832f8afbab78a845d86e