### PR TITLE
Add log purge scheduling with retention option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,12 @@ La mappatura viene salvata nel meta `_tts_trello_map` come array serializzato da
 
 Ogni elemento dell'array associa una lista Trello al canale social su cui pubblicare.
 
+## Pulizia dei log
+
+Il plugin registra gli eventi nella tabella personalizzata `tts_logs`.
+Ogni giorno viene eseguita automaticamente un'operazione di pulizia che elimina i
+record più vecchi di un numero di giorni configurabile (30 giorni per impostazione predefinita).
+
+Il periodo di conservazione è modificabile dalla pagina delle impostazioni del plugin tramite
+il campo **Log Retention (days)**.
+

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
@@ -146,6 +146,22 @@ class TTS_Settings {
             'tts_settings',
             'tts_template_options'
         );
+
+        // Logging options.
+        add_settings_section(
+            'tts_logging_options',
+            __( 'Logging Options', 'trello-social-auto-publisher' ),
+            '__return_false',
+            'tts_settings'
+        );
+
+        add_settings_field(
+            'log_retention_days',
+            __( 'Log Retention (days)', 'trello-social-auto-publisher' ),
+            array( $this, 'render_log_retention_days_field' ),
+            'tts_settings',
+            'tts_logging_options'
+        );
     }
 
     /**
@@ -232,6 +248,15 @@ class TTS_Settings {
         $options = get_option( 'tts_settings', array() );
         $value   = isset( $options['instagram_template'] ) ? esc_attr( $options['instagram_template'] ) : '';
         echo '<input type="text" name="tts_settings[instagram_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url}" />';
+    }
+
+    /**
+     * Render field for log retention period.
+     */
+    public function render_log_retention_days_field() {
+        $options = get_option( 'tts_settings', array() );
+        $value   = isset( $options['log_retention_days'] ) ? intval( $options['log_retention_days'] ) : 30;
+        echo '<input type="number" min="1" name="tts_settings[log_retention_days]" value="' . esc_attr( $value ) . '" class="small-text" />';
     }
 }
 


### PR DESCRIPTION
## Summary
- purge old log entries based on configurable retention period
- schedule daily cleanup of tts logs
- document log retention setting

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/tts-logger.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68c040495970832f96df754629fc1f66