### PR TITLE
feat: publish to Facebook via Graph API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,12 @@ Questo progetto pubblica automaticamente contenuti sui social a partire da Trell
 3. All'interno dell'editor del post type `tts_client` inserisci Key, Token e Secret nei campi dedicati del metabox *Client Credentials*.
 4. Il Secret viene usato per validare le chiamate webhook. Trello invierà l'header `X-Trello-Webhook` firmato; in alternativa è possibile inviare un parametro `hmac` calcolato con `hash_hmac('sha256', $payload, $secret)`.
 
+## Token Facebook e permessi
+
+Per pubblicare contenuti su Facebook è necessario un **Page Access Token** dotato dei permessi `pages_manage_posts` e `pages_read_engagement`.
+
+Inserisci nel campo *Facebook Access Token* del client il valore nel formato `{ID-pagina}|{access-token}` dove `{ID-pagina}` è l'identificativo della pagina su cui pubblicare.
+
 ## Mappatura Trello → Canali Social
 
 Nel metabox del custom post type `tts_client` è possibile definire una mappatura tra l'`idList` di Trello e il relativo `canale_social`.

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
@@ -24,15 +24,63 @@ class TTS_Publisher_Facebook {
      */
     public function publish( $post_id, $credentials, $message ) {
         if ( empty( $credentials ) ) {
-            $message = __( 'Facebook token missing', 'trello-social-auto-publisher' );
-            tts_log_event( $post_id, 'facebook', 'error', $message, '' );
+            $error = __( 'Facebook token missing', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'facebook', 'error', $error, '' );
             tts_notify_publication( $post_id, 'error', 'facebook' );
-            return $message;
+            return new \WP_Error( 'facebook_no_token', $error );
         }
 
-        $response = __( 'Published to Facebook', 'trello-social-auto-publisher' );
-        tts_log_event( $post_id, 'facebook', 'success', $response, array( 'message' => $message ) );
-        tts_notify_publication( $post_id, 'success', 'facebook' );
-        return $response;
+        list( $page_id, $token ) = array_pad( explode( '|', $credentials, 2 ), 2, '' );
+        if ( empty( $page_id ) || empty( $token ) ) {
+            $error = __( 'Invalid Facebook credentials', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'facebook', 'error', $error, '' );
+            tts_notify_publication( $post_id, 'error', 'facebook' );
+            return new \WP_Error( 'facebook_bad_credentials', $error );
+        }
+
+        $endpoint = sprintf( 'https://graph.facebook.com/%s/feed', $page_id );
+
+        $body = array(
+            'message'      => $message,
+            'access_token' => $token,
+        );
+
+        $link = get_permalink( $post_id );
+        if ( $link ) {
+            $body['link'] = $link;
+        }
+
+        $attachments = get_attached_media( 'image', $post_id );
+        $index       = 0;
+        foreach ( $attachments as $attachment ) {
+            $url = wp_get_attachment_url( $attachment->ID );
+            if ( $url ) {
+                $body[ 'attached_media[' . $index . ']' ] = wp_json_encode( array( 'link' => $url ) );
+                $index++;
+            }
+        }
+
+        $result = wp_remote_post( $endpoint, array( 'body' => $body ) );
+
+        if ( is_wp_error( $result ) ) {
+            $error = $result->get_error_message();
+            tts_log_event( $post_id, 'facebook', 'error', $error, '' );
+            tts_notify_publication( $post_id, 'error', 'facebook' );
+            return $result;
+        }
+
+        $code = wp_remote_retrieve_response_code( $result );
+        $data = json_decode( wp_remote_retrieve_body( $result ), true );
+
+        if ( 200 === $code && isset( $data['id'] ) ) {
+            $response = __( 'Published to Facebook', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'facebook', 'success', $response, $data );
+            return $response;
+        }
+
+        $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+        tts_log_event( $post_id, 'facebook', 'error', $error, $data );
+        tts_notify_publication( $post_id, 'error', 'facebook' );
+        return new \WP_Error( 'facebook_error', $error, $data );
     }
 }


### PR DESCRIPTION
## Summary
- implement Facebook publishing using wp_remote_post
- document required Facebook token and permissions

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php`


------
https://chatgpt.com/codex/tasks/task_e_68c08b0ac2ac832f8c06f9d27a20f61a