### PR TITLE
Implement Instagram publishing via Graph API

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ Per pubblicare contenuti su Facebook è necessario un **Page Access Token** dota
 
 Inserisci nel campo *Facebook Access Token* del client il valore nel formato `{ID-pagina}|{access-token}` dove `{ID-pagina}` è l'identificativo della pagina su cui pubblicare.
 
+## Token Instagram e ig_user_id
+
+Per pubblicare contenuti su Instagram è necessario un account **Business** o **Creator** collegato a una pagina Facebook.
+
+1. Crea un'app su [Meta for Developers](https://developers.facebook.com/apps/) e abilita l'**Instagram Graph API**.
+2. Genera un **Access Token** con i permessi `instagram_basic`, `pages_show_list`, `instagram_content_publish` e `pages_read_engagement`. Puoi utilizzare il [Graph API Explorer](https://developers.facebook.com/tools/explorer/) per ottenere un token di prova e poi convertirlo in un token di lunga durata.
+3. Recupera l'`ig_user_id` dell'account chiamando:
+
+   ```
+   https://graph.facebook.com/v17.0/{page-id}?fields=instagram_business_account&access_token={page-access-token}
+   ```
+
+   Il valore `instagram_business_account.id` è l'`ig_user_id`.
+4. Inserisci nel campo *Instagram Access Token* del client il valore nel formato `{ig_user_id}|{access-token}`.
+
 ## Mappatura Trello → Canali Social
 
 Nel metabox del custom post type `tts_client` è possibile definire una mappatura tra l'`idList` di Trello e il relativo `canale_social`.

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php
@@ -27,12 +27,98 @@ class TTS_Publisher_Instagram {
             $message = __( 'Instagram token missing', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'instagram', 'error', $message, '' );
             tts_notify_publication( $post_id, 'error', 'instagram' );
-            return $message;
+            return new \WP_Error( 'instagram_no_token', $message );
         }
 
-        $response = __( 'Published to Instagram', 'trello-social-auto-publisher' );
-        tts_log_event( $post_id, 'instagram', 'success', $response, array( 'message' => $message ) );
-        tts_notify_publication( $post_id, 'success', 'instagram' );
-        return $response;
+        list( $ig_user_id, $token ) = array_pad( explode( '|', $credentials, 2 ), 2, '' );
+        if ( empty( $ig_user_id ) || empty( $token ) ) {
+            $error = __( 'Invalid Instagram credentials', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'instagram', 'error', $error, '' );
+            tts_notify_publication( $post_id, 'error', 'instagram' );
+            return new \WP_Error( 'instagram_bad_credentials', $error );
+        }
+
+        $image_url = '';
+        $images    = get_attached_media( 'image', $post_id );
+        if ( ! empty( $images ) ) {
+            $image_url = wp_get_attachment_url( reset( $images )->ID );
+        }
+
+        $video_url = '';
+        if ( empty( $image_url ) ) {
+            $videos = get_attached_media( 'video', $post_id );
+            if ( ! empty( $videos ) ) {
+                $video_url = wp_get_attachment_url( reset( $videos )->ID );
+            }
+        }
+
+        if ( empty( $image_url ) && empty( $video_url ) ) {
+            $error = __( 'No image or video to publish', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'instagram', 'error', $error, '' );
+            tts_notify_publication( $post_id, 'error', 'instagram' );
+            return new \WP_Error( 'instagram_no_media', $error );
+        }
+
+        $endpoint = sprintf( 'https://graph.facebook.com/%s/media', $ig_user_id );
+        $body     = array(
+            'caption'      => $message,
+            'access_token' => $token,
+        );
+
+        if ( $image_url ) {
+            $body['image_url'] = $image_url;
+        } else {
+            $body['media_type'] = 'VIDEO';
+            $body['video_url']  = $video_url;
+        }
+
+        $result = wp_remote_post( $endpoint, array( 'body' => $body ) );
+
+        if ( is_wp_error( $result ) ) {
+            $error = $result->get_error_message();
+            tts_log_event( $post_id, 'instagram', 'error', $error, '' );
+            tts_notify_publication( $post_id, 'error', 'instagram' );
+            return $result;
+        }
+
+        $code = wp_remote_retrieve_response_code( $result );
+        $data = json_decode( wp_remote_retrieve_body( $result ), true );
+
+        if ( 200 !== $code || empty( $data['id'] ) ) {
+            $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'instagram', 'error', $error, $data );
+            tts_notify_publication( $post_id, 'error', 'instagram' );
+            return new \WP_Error( 'instagram_error', $error, $data );
+        }
+
+        $publish_endpoint = sprintf( 'https://graph.facebook.com/%s/media_publish', $ig_user_id );
+        $publish_body     = array(
+            'creation_id'  => $data['id'],
+            'access_token' => $token,
+        );
+
+        $publish_result = wp_remote_post( $publish_endpoint, array( 'body' => $publish_body ) );
+
+        if ( is_wp_error( $publish_result ) ) {
+            $error = $publish_result->get_error_message();
+            tts_log_event( $post_id, 'instagram', 'error', $error, '' );
+            tts_notify_publication( $post_id, 'error', 'instagram' );
+            return $publish_result;
+        }
+
+        $publish_code = wp_remote_retrieve_response_code( $publish_result );
+        $publish_data = json_decode( wp_remote_retrieve_body( $publish_result ), true );
+
+        if ( 200 === $publish_code && isset( $publish_data['id'] ) ) {
+            $response = __( 'Published to Instagram', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'instagram', 'success', $response, $publish_data );
+            tts_notify_publication( $post_id, 'success', 'instagram' );
+            return $response;
+        }
+
+        $error = isset( $publish_data['error']['message'] ) ? $publish_data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+        tts_log_event( $post_id, 'instagram', 'error', $error, $publish_data );
+        tts_notify_publication( $post_id, 'error', 'instagram' );
+        return new \WP_Error( 'instagram_error', $error, $publish_data );
     }
 }


### PR DESCRIPTION
## Summary
- implement Instagram publish workflow calling Graph API /media and /media_publish endpoints
- support image and video formats and log results
- document how to obtain ig_user_id and token from Meta

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php`


------
https://chatgpt.com/codex/tasks/task_e_68c08bf0d7ac832fb5752c6c972308e5