### PR TITLE
Add YouTube publishing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ La mappatura viene salvata nel meta `_tts_trello_map` come array serializzato da
 
 Ogni elemento dell'array associa una lista Trello al canale social su cui pubblicare.
 
+Canali supportati: `facebook`, `instagram`, `youtube`.
+
 ## Pulizia dei log
 
 Il plugin registra gli eventi nella tabella personalizzata `tts_logs`.

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php
@@ -73,6 +73,7 @@ class TTS_Client {
         $board_id      = get_post_meta( $post->ID, '_tts_trello_board', true );
         $fb_token     = get_post_meta( $post->ID, '_tts_fb_token', true );
         $ig_token     = get_post_meta( $post->ID, '_tts_ig_token', true );
+        $yt_token     = get_post_meta( $post->ID, '_tts_yt_token', true );
         $trello_map   = get_post_meta( $post->ID, '_tts_trello_map', true );
 
         if ( ! is_array( $trello_map ) ) {
@@ -96,6 +97,9 @@ class TTS_Client {
 
         echo '<p><label for="tts_ig_token">' . esc_html__( 'Instagram Access Token', 'trello-social-auto-publisher' ) . '</label>';
         echo '<input type="text" id="tts_ig_token" name="tts_ig_token" value="' . esc_attr( $ig_token ) . '" class="widefat" /></p>';
+
+        echo '<p><label for="tts_yt_token">' . esc_html__( 'YouTube Access Token', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<input type="text" id="tts_yt_token" name="tts_yt_token" value="' . esc_attr( $yt_token ) . '" class="widefat" /></p>';
 
         ?>
         <div id="tts_trello_map">
@@ -160,6 +164,7 @@ class TTS_Client {
             'tts_trello_board'  => '_tts_trello_board',
             'tts_fb_token'      => '_tts_fb_token',
             'tts_ig_token'      => '_tts_ig_token',
+            'tts_yt_token'      => '_tts_yt_token',
         );
 
         foreach ( $fields as $field => $meta_key ) {

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
@@ -102,6 +102,7 @@ class TTS_CPT {
         $templates = array(
             'facebook'  => isset( $options['facebook_template'] ) ? $options['facebook_template'] : '',
             'instagram' => isset( $options['instagram_template'] ) ? $options['instagram_template'] : '',
+            'youtube'   => isset( $options['youtube_template'] ) ? $options['youtube_template'] : '',
         );
 
         echo '<div class="tts-preview">';

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
@@ -71,6 +71,7 @@ class TTS_Scheduler {
         $tokens = array(
             'facebook'  => get_post_meta( $client_id, '_tts_fb_token', true ),
             'instagram' => get_post_meta( $client_id, '_tts_ig_token', true ),
+            'youtube'   => get_post_meta( $client_id, '_tts_yt_token', true ),
         );
 
         $options = get_option( 'tts_settings', array() );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
@@ -104,7 +104,7 @@ class TTS_Settings {
             '__return_false',
             'tts_settings'
         );
-        $channels = array( 'facebook', 'instagram' );
+        $channels = array( 'facebook', 'instagram', 'youtube' );
         $params   = array( 'source', 'medium', 'campaign' );
 
         foreach ( $channels as $channel ) {
@@ -143,6 +143,14 @@ class TTS_Settings {
             'instagram_template',
             __( 'Instagram Template', 'trello-social-auto-publisher' ),
             array( $this, 'render_instagram_template_field' ),
+            'tts_settings',
+            'tts_template_options'
+        );
+
+        add_settings_field(
+            'youtube_template',
+            __( 'YouTube Template', 'trello-social-auto-publisher' ),
+            array( $this, 'render_youtube_template_field' ),
             'tts_settings',
             'tts_template_options'
         );
@@ -248,6 +256,15 @@ class TTS_Settings {
         $options = get_option( 'tts_settings', array() );
         $value   = isset( $options['instagram_template'] ) ? esc_attr( $options['instagram_template'] ) : '';
         echo '<input type="text" name="tts_settings[instagram_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url}" />';
+    }
+
+    /**
+     * Render field for YouTube template.
+     */
+    public function render_youtube_template_field() {
+        $options = get_option( 'tts_settings', array() );
+        $value   = isset( $options['youtube_template'] ) ? esc_attr( $options['youtube_template'] ) : '';
+        echo '<input type="text" name="tts_settings[youtube_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url}" />';
     }
 
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-youtube.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-youtube.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * YouTube publisher.
+ *
+ * @package TrelloSocialAutoPublisher\Publishers
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Handles publishing to YouTube.
+ */
+class TTS_Publisher_YouTube {
+
+    /**
+     * Publish the post to YouTube.
+     *
+     * @param int    $post_id     Post ID.
+     * @param string $token       OAuth 2.0 access token.
+     * @param string $message     Message to publish.
+     * @return string|\WP_Error  Log message.
+     */
+    public function publish( $post_id, $token, $message ) {
+        if ( empty( $token ) ) {
+            $error = __( 'YouTube token missing', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'youtube', 'error', $error, '' );
+            tts_notify_publication( $post_id, 'error', 'youtube' );
+            return new \WP_Error( 'youtube_no_token', $error );
+        }
+
+        $videos = get_attached_media( 'video', $post_id );
+        if ( empty( $videos ) ) {
+            $error = __( 'No video to publish', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'youtube', 'error', $error, '' );
+            tts_notify_publication( $post_id, 'error', 'youtube' );
+            return new \WP_Error( 'youtube_no_video', $error );
+        }
+
+        $video      = reset( $videos );
+        $video_path = get_attached_file( $video->ID );
+        if ( empty( $video_path ) || ! file_exists( $video_path ) ) {
+            $error = __( 'Video file not found', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'youtube', 'error', $error, '' );
+            tts_notify_publication( $post_id, 'error', 'youtube' );
+            return new \WP_Error( 'youtube_video_missing', $error );
+        }
+
+        $snippet = array(
+            'title'           => get_the_title( $post_id ),
+            'description'     => $message,
+            'categoryId'      => '22',
+            'shortsVideoType' => 'SHORTS',
+        );
+
+        $status = array(
+            'privacyStatus' => 'public',
+        );
+
+        $metadata = array(
+            'snippet' => $snippet,
+            'status'  => $status,
+        );
+
+        $boundary  = wp_generate_password( 24, false );
+        $delimiter = '-------' . $boundary;
+
+        $body  = "--$delimiter\r\n";
+        $body .= "Content-Type: application/json; charset=UTF-8\r\n\r\n";
+        $body .= wp_json_encode( $metadata ) . "\r\n";
+
+        $body .= "--$delimiter\r\n";
+        $body .= "Content-Type: video/mp4\r\n";
+        $body .= "Content-Transfer-Encoding: binary\r\n";
+        $body .= 'Content-Disposition: form-data; name="video"; filename="' . basename( $video_path ) . '"' . "\r\n\r\n";
+        $body .= file_get_contents( $video_path ) . "\r\n";
+        $body .= "--$delimiter--";
+
+        $endpoint = 'https://www.googleapis.com/upload/youtube/v3/videos?part=snippet,status&uploadType=multipart';
+        $result   = wp_remote_post( $endpoint, array(
+            'headers' => array(
+                'Authorization' => 'Bearer ' . $token,
+                'Content-Type'  => 'multipart/related; boundary=' . $delimiter,
+            ),
+            'body'    => $body,
+            'timeout' => 60,
+        ) );
+
+        if ( is_wp_error( $result ) ) {
+            $error = $result->get_error_message();
+            tts_log_event( $post_id, 'youtube', 'error', $error, '' );
+            tts_notify_publication( $post_id, 'error', 'youtube' );
+            return $result;
+        }
+
+        $code = wp_remote_retrieve_response_code( $result );
+        $data = json_decode( wp_remote_retrieve_body( $result ), true );
+
+        if ( 200 === $code && ! empty( $data['id'] ) ) {
+            $response = __( 'Published to YouTube', 'trello-social-auto-publisher' );
+            tts_log_event( $post_id, 'youtube', 'success', $response, $data );
+            return $response;
+        }
+
+        $error = isset( $data['error']['message'] ) ? $data['error']['message'] : __( 'Unknown error', 'trello-social-auto-publisher' );
+        tts_log_event( $post_id, 'youtube', 'error', $error, $data );
+        tts_notify_publication( $post_id, 'error', 'youtube' );
+        return new \WP_Error( 'youtube_error', $error, $data );
+    }
+}


### PR DESCRIPTION
## Summary
- add YouTube publisher using YouTube Data API uploads
- allow storing client OAuth tokens for YouTube and expose template and UTM settings
- document Trello list mapping including YouTube channel

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-youtube.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php`


------
https://chatgpt.com/codex/tasks/task_e_68c08ca87b04832fbb240294da44b51e