### PR TITLE
Add TikTok publishing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Per pubblicare contenuti su Instagram è necessario un account **Business** o **
    Il valore `instagram_business_account.id` è l'`ig_user_id`.
 4. Inserisci nel campo *Instagram Access Token* del client il valore nel formato `{ig_user_id}|{access-token}`.
 
+## Token TikTok Business
+
+Per pubblicare contenuti su TikTok è necessario un account **Business** abilitato alle TikTok Marketing/Open API.
+
+1. Crea un'app su [TikTok for Developers](https://developers.tiktok.com/).
+2. Genera un **Access Token** con i permessi necessari per l'upload e la pubblicazione dei video.
+3. Inserisci il token nel campo *TikTok Access Token* del client.
+
 ## Mappatura Trello → Canali Social
 
 Nel metabox del custom post type `tts_client` è possibile definire una mappatura tra l'`idList` di Trello e il relativo `canale_social`.
@@ -50,7 +58,7 @@ La mappatura viene salvata nel meta `_tts_trello_map` come array serializzato da
 
 Ogni elemento dell'array associa una lista Trello al canale social su cui pubblicare.
 
-Canali supportati: `facebook`, `instagram`, `youtube`.
+Canali supportati: `facebook`, `instagram`, `youtube`, `tiktok`.
 
 ## Pulizia dei log
 

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php
@@ -74,6 +74,7 @@ class TTS_Client {
         $fb_token     = get_post_meta( $post->ID, '_tts_fb_token', true );
         $ig_token     = get_post_meta( $post->ID, '_tts_ig_token', true );
         $yt_token     = get_post_meta( $post->ID, '_tts_yt_token', true );
+        $tt_token     = get_post_meta( $post->ID, '_tts_tt_token', true );
         $trello_map   = get_post_meta( $post->ID, '_tts_trello_map', true );
 
         if ( ! is_array( $trello_map ) ) {
@@ -100,6 +101,9 @@ class TTS_Client {
 
         echo '<p><label for="tts_yt_token">' . esc_html__( 'YouTube Access Token', 'trello-social-auto-publisher' ) . '</label>';
         echo '<input type="text" id="tts_yt_token" name="tts_yt_token" value="' . esc_attr( $yt_token ) . '" class="widefat" /></p>';
+
+        echo '<p><label for="tts_tt_token">' . esc_html__( 'TikTok Access Token', 'trello-social-auto-publisher' ) . '</label>';
+        echo '<input type="text" id="tts_tt_token" name="tts_tt_token" value="' . esc_attr( $tt_token ) . '" class="widefat" /></p>';
 
         ?>
         <div id="tts_trello_map">
@@ -165,6 +169,7 @@ class TTS_Client {
             'tts_fb_token'      => '_tts_fb_token',
             'tts_ig_token'      => '_tts_ig_token',
             'tts_yt_token'      => '_tts_yt_token',
+            'tts_tt_token'      => '_tts_tt_token',
         );
 
         foreach ( $fields as $field => $meta_key ) {

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
@@ -72,6 +72,7 @@ class TTS_Scheduler {
             'facebook'  => get_post_meta( $client_id, '_tts_fb_token', true ),
             'instagram' => get_post_meta( $client_id, '_tts_ig_token', true ),
             'youtube'   => get_post_meta( $client_id, '_tts_yt_token', true ),
+            'tiktok'    => get_post_meta( $client_id, '_tts_tt_token', true ),
         );
 
         $options = get_option( 'tts_settings', array() );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
@@ -104,7 +104,7 @@ class TTS_Settings {
             '__return_false',
             'tts_settings'
         );
-        $channels = array( 'facebook', 'instagram', 'youtube' );
+        $channels = array( 'facebook', 'instagram', 'youtube', 'tiktok' );
         $params   = array( 'source', 'medium', 'campaign' );
 
         foreach ( $channels as $channel ) {
@@ -151,6 +151,14 @@ class TTS_Settings {
             'youtube_template',
             __( 'YouTube Template', 'trello-social-auto-publisher' ),
             array( $this, 'render_youtube_template_field' ),
+            'tts_settings',
+            'tts_template_options'
+        );
+
+        add_settings_field(
+            'tiktok_template',
+            __( 'TikTok Template', 'trello-social-auto-publisher' ),
+            array( $this, 'render_tiktok_template_field' ),
             'tts_settings',
             'tts_template_options'
         );
@@ -265,6 +273,15 @@ class TTS_Settings {
         $options = get_option( 'tts_settings', array() );
         $value   = isset( $options['youtube_template'] ) ? esc_attr( $options['youtube_template'] ) : '';
         echo '<input type="text" name="tts_settings[youtube_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url}" />';
+    }
+
+    /**
+     * Render field for TikTok template.
+     */
+    public function render_tiktok_template_field() {
+        $options = get_option( 'tts_settings', array() );
+        $value   = isset( $options['tiktok_template'] ) ? esc_attr( $options['tiktok_template'] ) : '';
+        echo '<input type="text" name="tts_settings[tiktok_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url}" />';
     }
 
     /**


### PR DESCRIPTION
## Summary
- add TikTok publisher class using video upload/publish endpoints
- store TikTok tokens, templates, and UTMs in client and settings
- document TikTok setup and include it in Trello mapping

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-tiktok.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68c08ddb4584832fa9876fb16069cf49