### PR TITLE
Add preferred channel selection with Trello mapping fallback

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-dashboard.js
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-dashboard.js
@@ -12,7 +12,7 @@ const PostList = ( { posts } ) => {
         {},
         createElement( 'tr', {}, [
           createElement( 'th', {}, 'Title' ),
-          createElement( 'th', {}, 'Channel' ),
+          createElement( 'th', {}, 'Preferred Channel' ),
           createElement( 'th', {}, 'Status' ),
           createElement( 'th', {}, 'Log' ),
         ] )
@@ -67,7 +67,9 @@ const Dashboard = () => {
         options: [
           { label: 'All', value: '' },
           { label: 'Facebook', value: 'facebook' },
-          { label: 'Instagram', value: 'instagram' }
+          { label: 'Instagram', value: 'instagram' },
+          { label: 'YouTube', value: 'youtube' },
+          { label: 'TikTok', value: 'tiktok' }
         ],
         onChange: ( value ) => setChannel( value )
       } ),

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php
@@ -21,6 +21,8 @@ class TTS_Client {
         add_action( 'init', array( $this, 'register_post_type' ) );
         add_action( 'add_meta_boxes_tts_client', array( $this, 'add_credentials_metabox' ) );
         add_action( 'save_post_tts_client', array( $this, 'save_credentials_metabox' ), 10, 2 );
+        add_action( 'add_meta_boxes_tts_social_post', array( $this, 'add_channel_metabox' ) );
+        add_action( 'save_post_tts_social_post', array( $this, 'save_channel_metabox' ), 10, 2 );
     }
 
     /**
@@ -198,6 +200,65 @@ class TTS_Client {
             }
         } else {
             delete_post_meta( $post_id, '_tts_trello_map' );
+        }
+    }
+
+    /**
+     * Add channel selection meta box for social posts.
+     */
+    public function add_channel_metabox() {
+        add_meta_box(
+            'tts_social_channel',
+            __( 'Preferred Channel', 'trello-social-auto-publisher' ),
+            array( $this, 'render_channel_metabox' ),
+            'tts_social_post',
+            'side'
+        );
+    }
+
+    /**
+     * Render channel selection field.
+     *
+     * @param WP_Post $post Current post object.
+     */
+    public function render_channel_metabox( $post ) {
+        wp_nonce_field( 'tts_channel_metabox', 'tts_channel_nonce' );
+        $channel  = get_post_meta( $post->ID, '_tts_social_channel', true );
+        $channel  = is_array( $channel ) ? $channel : ( $channel ? array( $channel ) : array() );
+        $options  = array(
+            'facebook'  => __( 'Facebook', 'trello-social-auto-publisher' ),
+            'instagram' => __( 'Instagram', 'trello-social-auto-publisher' ),
+            'youtube'   => __( 'YouTube', 'trello-social-auto-publisher' ),
+            'tiktok'    => __( 'TikTok', 'trello-social-auto-publisher' ),
+        );
+        foreach ( $options as $key => $label ) {
+            $checked = in_array( $key, $channel, true ) ? 'checked="checked"' : '';
+            echo '<p><label><input type="checkbox" name="tts_social_channel[]" value="' . esc_attr( $key ) . '" ' . $checked . ' /> ' . esc_html( $label ) . '</label></p>';
+        }
+    }
+
+    /**
+     * Save channel selection meta box.
+     *
+     * @param int     $post_id Post ID.
+     * @param WP_Post $post    Post object.
+     */
+    public function save_channel_metabox( $post_id, $post ) {
+        if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+            return;
+        }
+        if ( ! isset( $_POST['tts_channel_nonce'] ) || ! wp_verify_nonce( $_POST['tts_channel_nonce'], 'tts_channel_metabox' ) ) {
+            return;
+        }
+        if ( ! current_user_can( 'edit_post', $post_id ) ) {
+            return;
+        }
+
+        if ( isset( $_POST['tts_social_channel'] ) && is_array( $_POST['tts_social_channel'] ) ) {
+            $channels = array_map( 'sanitize_text_field', $_POST['tts_social_channel'] );
+            update_post_meta( $post_id, '_tts_social_channel', $channels );
+        } else {
+            delete_post_meta( $post_id, '_tts_social_channel' );
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow selecting preferred channels on social posts
- fall back to Trello list mapping when channel is missing
- expose new channel options on dashboard filters

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php`
- `node --check wp-content/plugins/trello-social-auto-publisher/admin/js/tts-dashboard.js`


------
https://chatgpt.com/codex/tasks/task_e_68c08f5c62e0832fbb722cac4bbd0473