### PR TITLE
Refactor Facebook publisher to use page ID and wp_remote_post

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
@@ -17,6 +17,9 @@ class TTS_Publisher_Facebook {
     /**
      * Publish the post to Facebook.
      *
+     * Requires the `pages_manage_posts` permission to publish and
+     * `pages_read_engagement` to read the response from the API.
+     *
      * @param int    $post_id     Post ID.
      * @param mixed  $credentials Credentials used for publishing.
      * @param string $message     Message to publish.
@@ -30,7 +33,17 @@ class TTS_Publisher_Facebook {
             return new \WP_Error( 'facebook_no_token', $error );
         }
 
-        list( $page_id, $token ) = array_pad( explode( '|', $credentials, 2 ), 2, '' );
+        $token   = $credentials;
+        $page_id = '';
+
+        // Allow credentials in the form page_id|token for backward compatibility.
+        if ( false !== strpos( $credentials, '|' ) ) {
+            list( $page_id, $token ) = array_pad( explode( '|', $credentials, 2 ), 2, '' );
+        } else {
+            // Retrieve the page ID from post meta when not included in the token.
+            $page_id = get_post_meta( $post_id, '_tts_fb_page_id', true );
+        }
+
         if ( empty( $page_id ) || empty( $token ) ) {
             $error = __( 'Invalid Facebook credentials', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'facebook', 'error', $error, '' );
@@ -38,28 +51,26 @@ class TTS_Publisher_Facebook {
             return new \WP_Error( 'facebook_bad_credentials', $error );
         }
 
-        $endpoint = sprintf( 'https://graph.facebook.com/%s/feed', $page_id );
-
         $body = array(
             'message'      => $message,
             'access_token' => $token,
         );
 
-        $link = get_permalink( $post_id );
-        if ( $link ) {
-            $body['link'] = $link;
-        }
-
         $attachments = get_attached_media( 'image', $post_id );
-        $index       = 0;
-        foreach ( $attachments as $attachment ) {
-            $url = wp_get_attachment_url( $attachment->ID );
-            if ( $url ) {
-                $body[ 'attached_media[' . $index . ']' ] = wp_json_encode( array( 'link' => $url ) );
-                $index++;
+        if ( ! empty( $attachments ) ) {
+            // Posting an image requires the photos edge and the "pages_manage_posts" permission.
+            $endpoint       = sprintf( 'https://graph.facebook.com/%s/photos', $page_id );
+            $body['source'] = wp_get_attachment_url( reset( $attachments )->ID );
+        } else {
+            // Text or link posts use the feed edge.
+            $endpoint = sprintf( 'https://graph.facebook.com/%s/feed', $page_id );
+            $link     = get_permalink( $post_id );
+            if ( $link ) {
+                $body['link'] = $link;
             }
         }
 
+        // Possible errors include expired tokens or insufficient permissions (e.g. missing "pages_manage_posts").
         $result = wp_remote_post( $endpoint, array( 'body' => $body ) );
 
         if ( is_wp_error( $result ) ) {
@@ -75,6 +86,7 @@ class TTS_Publisher_Facebook {
         if ( 200 === $code && isset( $data['id'] ) ) {
             $response = __( 'Published to Facebook', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'facebook', 'success', $response, $data );
+            tts_notify_publication( $post_id, 'success', 'facebook' );
             return $response;
         }
 


### PR DESCRIPTION
## Summary
- allow Facebook page ID to come from post meta when not included in token
- send posts to Graph API feed or photos edge via wp_remote_post
- log success and errors with tts_log_event and tts_notify_publication

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php`


------
https://chatgpt.com/codex/tasks/task_e_68c09208d01c832fae3f2c007fd791e6