### PR TITLE
Add TikTok publishing support in scheduler

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
@@ -73,6 +73,7 @@ class TTS_Scheduler {
             'instagram' => get_post_meta( $client_id, '_tts_ig_token', true ),
             // Added support for YouTube uploads.
             'youtube'   => get_post_meta( $client_id, '_tts_yt_token', true ),
+            // Added support for TikTok uploads.
             'tiktok'    => get_post_meta( $client_id, '_tts_tt_token', true ),
         );
 

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-tiktok.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-tiktok.php
@@ -17,6 +17,9 @@ class TTS_Publisher_TikTok {
     /**
      * Publish the post to TikTok.
      *
+     * Requires an OAuth 2.0 access token granted with the `video.upload`
+     * scope in order to send media and create the video post.
+     *
      * @param int    $post_id Post ID.
      * @param string $token   OAuth 2.0 access token.
      * @param string $message Video description to publish.
@@ -24,7 +27,7 @@ class TTS_Publisher_TikTok {
      */
     public function publish( $post_id, $token, $message ) {
         if ( empty( $token ) ) {
-            $error = __( 'TikTok token missing', 'trello-social-auto-publisher' );
+            $error = __( 'TikTok token missing or lacks video.upload scope', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
             tts_notify_publication( $post_id, 'error', 'tiktok' );
             return new \WP_Error( 'tiktok_no_token', $error );


### PR DESCRIPTION
## Summary
- document required `video.upload` scope for TikTok publisher
- clarify scheduler token retrieval for TikTok uploads

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-tiktok.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php`


------
https://chatgpt.com/codex/tasks/task_e_68c094ac7a80832f8fd86f5266a411c0