### PR TITLE
Enable Trello webhook handshake

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php
@@ -29,8 +29,9 @@ class TTS_Webhook {
             'tts/v1',
             '/trello-webhook',
             array(
-                'methods'  => 'POST',
-                'callback' => array( $this, 'handle_trello_webhook' ),
+                'methods'             => array( 'POST', 'GET', 'HEAD' ),
+                'callback'            => array( $this, 'handle_trello_webhook' ),
+                'permission_callback' => '__return_true',
             )
         );
     }
@@ -43,6 +44,10 @@ class TTS_Webhook {
      * @return WP_REST_Response|WP_Error
      */
     public function handle_trello_webhook( WP_REST_Request $request ) {
+        if ( 'POST' !== $request->get_method() ) {
+            return rest_ensure_response( 'OK' );
+        }
+
         $data  = $request->get_json_params();
         $card  = isset( $data['action']['data']['card'] ) ? $data['action']['data']['card'] : array();
         $result = array(


### PR DESCRIPTION
## Summary
- allow Trello webhook to use GET and HEAD for handshake
- respond OK to non-POST webhook requests

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php`


------
https://chatgpt.com/codex/tasks/task_e_68c121e76050832f91978b9abb3c1403