### PR TITLE
Add nonce verification for publish action

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -177,6 +177,11 @@ class TTS_Admin {
 
         // Handle publish now action.
         if ( isset( $_GET['action'], $_GET['post'] ) && 'publish' === $_GET['action'] ) {
+            if ( ! current_user_can( 'manage_options' ) ) {
+                wp_die( esc_html__( 'Sorry, you are not allowed to publish this post.', 'trello-social-auto-publisher' ) );
+            }
+
+            check_admin_referer( 'tts_publish_social_post_' . absint( $_GET['post'] ) );
             do_action( 'tts_publish_social_post', array( 'post_id' => absint( $_GET['post'] ) ) );
             echo '<div class="notice notice-success"><p>' . esc_html__( 'Post published.', 'trello-social-auto-publisher' ) . '</p></div>';
         }
@@ -261,8 +266,20 @@ class TTS_Social_Posts_Table extends WP_List_Table {
      * @return string
      */
     public function column_title( $item ) {
+        $publish_url = wp_nonce_url(
+            add_query_arg(
+                array(
+                    'page'   => 'tts-social-posts',
+                    'action' => 'publish',
+                    'post'   => $item['ID'],
+                ),
+                admin_url( 'admin.php' )
+            ),
+            'tts_publish_social_post_' . $item['ID']
+        );
+
         $actions = array(
-            'publish'  => sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( array( 'page' => 'tts-social-posts', 'action' => 'publish', 'post' => $item['ID'] ), admin_url( 'admin.php' ) ) ), __( 'Publish Now', 'trello-social-auto-publisher' ) ),
+            'publish'  => sprintf( '<a href="%s">%s</a>', esc_url( $publish_url ), __( 'Publish Now', 'trello-social-auto-publisher' ) ),
             'edit'     => sprintf( '<a href="%s">%s</a>', get_edit_post_link( $item['ID'] ), __( 'Edit', 'trello-social-auto-publisher' ) ),
             'view_log' => sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( array( 'page' => 'tts-social-posts', 'action' => 'log', 'post' => $item['ID'] ), admin_url( 'admin.php' ) ) ), __( 'View Log', 'trello-social-auto-publisher' ) ),
         );

--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -177,7 +177,7 @@ class TTS_Admin {
 
         // Handle publish now action.
         if ( isset( $_GET['action'], $_GET['post'] ) && 'publish' === $_GET['action'] ) {
-            if ( ! current_user_can( 'manage_options' ) ) {
+            if ( ! current_user_can( 'publish_posts' ) ) {
                 wp_die( esc_html__( 'Sorry, you are not allowed to publish this post.', 'trello-social-auto-publisher' ) );
             }
 


### PR DESCRIPTION
## Summary
- secure publish action by checking nonce and user capabilities
- add nonce to publish row action links

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68c122772e40832f86ee18c905fc6f20