### PR TITLE
Ensure POST data is unslashed before sanitization

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php
@@ -180,7 +180,7 @@ class TTS_Client {
 
         foreach ( $fields as $field => $meta_key ) {
             if ( isset( $_POST[ $field ] ) && '' !== $_POST[ $field ] ) {
-                update_post_meta( $post_id, $meta_key, sanitize_text_field( $_POST[ $field ] ) );
+                update_post_meta( $post_id, $meta_key, sanitize_text_field( wp_unslash( $_POST[ $field ] ) ) );
             } else {
                 delete_post_meta( $post_id, $meta_key );
             }
@@ -188,7 +188,7 @@ class TTS_Client {
 
         if ( isset( $_POST['tts_trello_map'] ) && is_array( $_POST['tts_trello_map'] ) ) {
             $map = array();
-            foreach ( $_POST['tts_trello_map'] as $row ) {
+            foreach ( wp_unslash( $_POST['tts_trello_map'] ) as $row ) {
                 if ( empty( $row['idList'] ) || empty( $row['canale_social'] ) ) {
                     continue;
                 }
@@ -259,7 +259,7 @@ class TTS_Client {
         }
 
         if ( isset( $_POST['tts_social_channel'] ) && is_array( $_POST['tts_social_channel'] ) ) {
-            $channels = array_map( 'sanitize_text_field', $_POST['tts_social_channel'] );
+            $channels = array_map( 'sanitize_text_field', wp_unslash( $_POST['tts_social_channel'] ) );
             update_post_meta( $post_id, '_tts_social_channel', $channels );
         } else {
             delete_post_meta( $post_id, '_tts_social_channel' );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
@@ -188,7 +188,7 @@ class TTS_CPT {
 
         if ( isset( $_POST['tts_schedule_nonce'] ) && wp_verify_nonce( $_POST['tts_schedule_nonce'], 'tts_schedule_metabox' ) ) {
             if ( isset( $_POST['_tts_publish_at'] ) && '' !== $_POST['_tts_publish_at'] ) {
-                update_post_meta( $post_id, '_tts_publish_at', sanitize_text_field( $_POST['_tts_publish_at'] ) );
+                update_post_meta( $post_id, '_tts_publish_at', sanitize_text_field( wp_unslash( $_POST['_tts_publish_at'] ) ) );
             } else {
                 delete_post_meta( $post_id, '_tts_publish_at' );
             }
@@ -196,7 +196,7 @@ class TTS_CPT {
 
         if ( isset( $_POST['tts_channel_nonce'] ) && wp_verify_nonce( $_POST['tts_channel_nonce'], 'tts_channel_metabox' ) ) {
             if ( isset( $_POST['_tts_social_channel'] ) && is_array( $_POST['_tts_social_channel'] ) ) {
-                $channels = array_map( 'sanitize_text_field', $_POST['_tts_social_channel'] );
+                $channels = array_map( 'sanitize_text_field', wp_unslash( $_POST['_tts_social_channel'] ) );
                 update_post_meta( $post_id, '_tts_social_channel', $channels );
             } else {
                 delete_post_meta( $post_id, '_tts_social_channel' );


### PR DESCRIPTION
## Summary
- unslash schedule date and channel selections before sanitizing in social post CPT
- sanitize client credential and channel fields after wp_unslash

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-client.php`
- `php /tmp/test_meta.php`

------
https://chatgpt.com/codex/tasks/task_e_68c128e586d8832f98d5aeff14192fe3