### PR TITLE
Store Trello social posts as drafts

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -483,6 +483,7 @@ class TTS_Social_Posts_Table extends WP_List_Table {
         $posts = get_posts(
             array(
                 'post_type'      => 'tts_social_post',
+                'post_status'    => 'any',
                 'posts_per_page' => -1,
             )
         );

--- a/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-dashboard.js
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-dashboard.js
@@ -45,7 +45,7 @@ const Dashboard = () => {
   const [ loading, setLoading ] = useState( true );
 
   useEffect( () => {
-    apiFetch( { path: '/wp/v2/tts_social_post?per_page=100&_fields=id,title,meta' } )
+    apiFetch( { path: '/wp/v2/tts_social_post?per_page=100&status=any&_fields=id,title,meta' } )
       .then( ( data ) => {
         setPosts( data );
         setLoading( false );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php
@@ -32,10 +32,12 @@ class TTS_CPT {
      */
     public function register_post_type() {
         $args = array(
-            'public'       => true,
-            'supports'     => array( 'title', 'editor', 'custom-fields', 'thumbnail' ),
-            'show_in_rest' => true,
-            'label'        => __( 'Social Posts', 'trello-social-auto-publisher' ),
+            'public'             => false,
+            'publicly_queryable' => false,
+            'show_ui'            => true,
+            'supports'           => array( 'title', 'editor', 'custom-fields', 'thumbnail' ),
+            'show_in_rest'       => true,
+            'label'              => __( 'Social Posts', 'trello-social-auto-publisher' ),
         );
 
         register_post_type( 'tts_social_post', $args );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php
@@ -190,7 +190,7 @@ class TTS_Webhook {
                 'post_title'   => sanitize_text_field( $result['name'] ),
                 'post_content' => wp_kses_post( $result['desc'] ),
                 'post_type'    => 'tts_social_post',
-                'post_status'  => 'publish',
+                'post_status'  => 'draft',
                 'meta_input'   => array( '_tts_client_id' => $client_id ),
             ),
             true


### PR DESCRIPTION
## Summary
- make social post CPT non-public and create posts as drafts
- fetch social posts regardless of publish status in admin and dashboard

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php`
- `node --check wp-content/plugins/trello-social-auto-publisher/admin/js/tts-dashboard.js`


------
https://chatgpt.com/codex/tasks/task_e_68c12b56406c832f85d25887327998bd