### PR TITLE
Add timeouts to external requests

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -128,7 +128,10 @@ class TTS_Admin {
             wp_send_json_error();
         }
 
-        $response = wp_remote_get( 'https://api.trello.com/1/boards/' . rawurlencode( $board ) . '/lists?key=' . rawurlencode( $key ) . '&token=' . rawurlencode( $token ) );
+        $response = wp_remote_get(
+            'https://api.trello.com/1/boards/' . rawurlencode( $board ) . '/lists?key=' . rawurlencode( $key ) . '&token=' . rawurlencode( $token ),
+            array( 'timeout' => 20 )
+        );
         if ( is_wp_error( $response ) ) {
             wp_send_json_error();
         }
@@ -205,7 +208,10 @@ class TTS_Admin {
 
             $boards = array();
             if ( $trello_key && $trello_token ) {
-                $response = wp_remote_get( 'https://api.trello.com/1/members/me/boards?key=' . rawurlencode( $trello_key ) . '&token=' . rawurlencode( $trello_token ) );
+                $response = wp_remote_get(
+                    'https://api.trello.com/1/members/me/boards?key=' . rawurlencode( $trello_key ) . '&token=' . rawurlencode( $trello_token ),
+                    array( 'timeout' => 20 )
+                );
                 if ( ! is_wp_error( $response ) ) {
                     $boards = json_decode( wp_remote_retrieve_body( $response ), true );
                 }

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
@@ -89,7 +89,7 @@ class TTS_Scheduler {
                 $trello_token = get_post_meta( $client_id, '_tts_trello_token', true );
                 if ( $card_id && $trello_key && $trello_token ) {
                     $url      = 'https://api.trello.com/1/cards/' . rawurlencode( $card_id ) . '?fields=idList&key=' . rawurlencode( $trello_key ) . '&token=' . rawurlencode( $trello_token );
-                    $response = wp_remote_get( $url );
+                    $response = wp_remote_get( $url, array( 'timeout' => 20 ) );
                     if ( ! is_wp_error( $response ) ) {
                         $body = json_decode( wp_remote_retrieve_body( $response ), true );
                         if ( isset( $body['idList'] ) ) {

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php
@@ -229,7 +229,12 @@ class TTS_Webhook {
                         continue;
                     }
 
-                    $response = wp_remote_get( $attachment['url'] );
+                    $response = wp_remote_get(
+                        $attachment['url'],
+                        array(
+                            'timeout' => 20,
+                        )
+                    );
                     if ( is_wp_error( $response ) ) {
                         tts_log_event( $post_id, 'webhook', 'error', __( 'Failed to retrieve attachment.', 'trello-social-auto-publisher' ), $attachment['url'] );
                         continue;

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
@@ -71,7 +71,13 @@ class TTS_Publisher_Facebook {
         }
 
         // Possible errors include expired tokens or insufficient permissions (e.g. missing "pages_manage_posts").
-        $result = wp_remote_post( $endpoint, array( 'body' => $body ) );
+        $result = wp_remote_post(
+            $endpoint,
+            array(
+                'body'    => $body,
+                'timeout' => 20,
+            )
+        );
 
         if ( is_wp_error( $result ) ) {
             $error = $result->get_error_message();

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php
@@ -76,7 +76,13 @@ class TTS_Publisher_Instagram {
             $body['video_url']  = $video_url;
         }
 
-        $result = wp_remote_post( $endpoint, array( 'body' => $body ) );
+        $result = wp_remote_post(
+            $endpoint,
+            array(
+                'body'    => $body,
+                'timeout' => 20,
+            )
+        );
 
         if ( is_wp_error( $result ) ) {
             $error = $result->get_error_message();
@@ -101,7 +107,13 @@ class TTS_Publisher_Instagram {
             'access_token' => $token,
         );
 
-        $publish_result = wp_remote_post( $publish_endpoint, array( 'body' => $publish_body ) );
+        $publish_result = wp_remote_post(
+            $publish_endpoint,
+            array(
+                'body'    => $publish_body,
+                'timeout' => 20,
+            )
+        );
 
         if ( is_wp_error( $publish_result ) ) {
             $error = $publish_result->get_error_message();

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-youtube.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-youtube.php
@@ -42,13 +42,14 @@ class TTS_Publisher_YouTube {
                 $token_resp = wp_remote_post(
                     'https://oauth2.googleapis.com/token',
                     array(
-                        'body' => array(
+                        'body'    => array(
                             'client_id'     => $creds['client_id'],
                             'client_secret' => $creds['client_secret'],
                             'refresh_token' => $creds['refresh_token'],
                             'grant_type'    => 'refresh_token',
                             'scope'         => 'https://www.googleapis.com/auth/youtube.upload',
                         ),
+                        'timeout' => 20,
                     )
                 );
                 if ( ! is_wp_error( $token_resp ) ) {

--- a/wp-content/plugins/trello-social-auto-publisher/includes/tts-notify.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/tts-notify.php
@@ -35,6 +35,7 @@ function tts_notify_publication( $post_id, $status, $channel ) {
             array(
                 'headers' => array( 'Content-Type' => 'application/json' ),
                 'body'    => wp_json_encode( array( 'text' => $message ) ),
+                'timeout' => 20,
             )
         );
         return;


### PR DESCRIPTION
## Summary
- add 20s timeout to Trello webhook media downloads
- ensure Facebook and Instagram publishers use 20s POST timeout
- apply consistent 20s timeout to Slack notifications, Trello API lookups and YouTube token refresh

## Testing
- `time php -r "require 'vendor/autoload.php'; try { Requests::get('http://127.0.0.1:8000', [], ['timeout'=>3]); } catch (Exception $e) { echo 'Error: '.$e->getMessage() . PHP_EOL; }"`

------
https://chatgpt.com/codex/tasks/task_e_68c134da9860832f8daeb483ffb1bec6