### PR TITLE
Add Trello metadata placeholders

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
@@ -260,7 +260,8 @@ class TTS_Settings {
     public function render_facebook_template_field() {
         $options = get_option( 'tts_settings', array() );
         $value   = isset( $options['facebook_template'] ) ? esc_attr( $options['facebook_template'] ) : '';
-        echo '<input type="text" name="tts_settings[facebook_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url}" />';
+        echo '<input type="text" name="tts_settings[facebook_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url} {due}" />';
+        echo '<p class="description">' . esc_html__( 'Available placeholders: {title}, {url}, {due}, {labels}, {client_name}', 'trello-social-auto-publisher' ) . '</p>';
     }
 
     /**
@@ -269,7 +270,8 @@ class TTS_Settings {
     public function render_instagram_template_field() {
         $options = get_option( 'tts_settings', array() );
         $value   = isset( $options['instagram_template'] ) ? esc_attr( $options['instagram_template'] ) : '';
-        echo '<input type="text" name="tts_settings[instagram_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url}" />';
+        echo '<input type="text" name="tts_settings[instagram_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url} {due}" />';
+        echo '<p class="description">' . esc_html__( 'Available placeholders: {title}, {url}, {due}, {labels}, {client_name}', 'trello-social-auto-publisher' ) . '</p>';
     }
 
     /**
@@ -278,7 +280,8 @@ class TTS_Settings {
     public function render_youtube_template_field() {
         $options = get_option( 'tts_settings', array() );
         $value   = isset( $options['youtube_template'] ) ? esc_attr( $options['youtube_template'] ) : '';
-        echo '<input type="text" name="tts_settings[youtube_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url}" />';
+        echo '<input type="text" name="tts_settings[youtube_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url} {due}" />';
+        echo '<p class="description">' . esc_html__( 'Available placeholders: {title}, {url}, {due}, {labels}, {client_name}', 'trello-social-auto-publisher' ) . '</p>';
     }
 
     /**
@@ -287,7 +290,8 @@ class TTS_Settings {
     public function render_tiktok_template_field() {
         $options = get_option( 'tts_settings', array() );
         $value   = isset( $options['tiktok_template'] ) ? esc_attr( $options['tiktok_template'] ) : '';
-        echo '<input type="text" name="tts_settings[tiktok_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url}" />';
+        echo '<input type="text" name="tts_settings[tiktok_template]" value="' . $value . '" class="regular-text" placeholder="{title} {url} {due}" />';
+        echo '<p class="description">' . esc_html__( 'Available placeholders: {title}, {url}, {due}, {labels}, {client_name}', 'trello-social-auto-publisher' ) . '</p>';
     }
 
     /**

--- a/wp-content/plugins/trello-social-auto-publisher/includes/tts-template.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/tts-template.php
@@ -50,10 +50,32 @@ function tts_apply_template( $template, $post_id, $channel ) {
 
     $url = get_permalink( $post_id );
     $url = tts_build_utm_url( $url, $channel );
+    $due    = get_post_meta( $post_id, '_trello_due', true );
+    $labels = get_post_meta( $post_id, '_trello_labels', true );
+    if ( is_array( $labels ) ) {
+        $label_names = array();
+        foreach ( $labels as $label ) {
+            if ( is_array( $label ) && ! empty( $label['name'] ) ) {
+                $label_names[] = $label['name'];
+            }
+        }
+        $labels = implode( ', ', $label_names );
+    }
+
+    $client_id   = get_post_meta( $post_id, '_tts_client_id', true );
+    $client_name = $client_id ? get_the_title( $client_id ) : '';
 
     $replacements = array(
-        '{title}' => get_the_title( $post_id ),
-        '{url}'   => $url,
+        '{title}'       => get_the_title( $post_id ),
+        '{content}'     => $post->post_content,
+        '{excerpt}'     => get_the_excerpt( $post_id ),
+        '{url}'         => $url,
+        '{due}'         => $due,
+        '{labels}'      => $labels,
+        '{client_name}' => $client_name,
+        '{publish_at}'  => get_post_meta( $post_id, '_tts_publish_at', true ),
+        '{trello_id}'   => get_post_meta( $post_id, '_trello_card_id', true ),
+        '{channel}'     => $channel,
     );
 
     return strtr( $template, $replacements );


### PR DESCRIPTION
## Summary
- expand `tts_apply_template` placeholders to support Trello due date, labels, client name and other fields
- document new placeholders in settings UI

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/tts-template.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php`
- `php /tmp/manual-test.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1d69b723c832f9f6f00824e5cca52