### PR TITLE
Add manual media metabox and use saved media in publishers

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php
@@ -23,6 +23,7 @@ class TTS_Admin {
         add_action( 'pre_get_posts', array( $this, 'filter_posts_by_client' ) );
         add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_dashboard_assets' ) );
         add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_wizard_assets' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_media_assets' ) );
         add_action( 'wp_ajax_tts_get_lists', array( $this, 'ajax_get_lists' ) );
     }
 
@@ -111,6 +112,30 @@ class TTS_Admin {
                 'ajaxUrl' => admin_url( 'admin-ajax.php' ),
                 'nonce'   => wp_create_nonce( 'tts_wizard' ),
             )
+        );
+    }
+
+    /**
+     * Enqueue assets for the manual media metabox.
+     *
+     * @param string $hook Current admin page hook.
+     */
+    public function enqueue_media_assets( $hook ) {
+        if ( ! in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
+            return;
+        }
+
+        $screen = get_current_screen();
+        if ( ! $screen || 'tts_social_post' !== $screen->post_type ) {
+            return;
+        }
+
+        wp_enqueue_script(
+            'tts-media',
+            plugin_dir_url( __FILE__ ) . 'js/tts-media.js',
+            array( 'jquery', 'media-editor' ),
+            '1.0',
+            true
         );
     }
 

--- a/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-media.js
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-media.js
@@ -1,0 +1,22 @@
+(function($){
+    $(function(){
+        var frame;
+        $('.tts-select-media').on('click', function(e){
+            e.preventDefault();
+            if(frame){
+                frame.open();
+                return;
+            }
+            frame = wp.media({
+                title: 'Seleziona o Carica file',
+                button: { text: 'Usa questo file' },
+                multiple: false
+            });
+            frame.on('select', function(){
+                var attachment = frame.state().get('selection').first().toJSON();
+                $('#tts_manual_media').val(attachment.id);
+            });
+            frame.open();
+        });
+    });
+})(jQuery);

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php
@@ -202,6 +202,14 @@ class TTS_Webhook {
             update_post_meta( $post_id, '_trello_attachments', $result['attachments'] );
             update_post_meta( $post_id, '_trello_due', $result['due'] );
 
+            $result['post_id']   = $post_id;
+            $result['client_id'] = $client_id;
+
+            if ( empty( $result['attachments'] ) ) {
+                tts_log_event( $post_id, 'webhook', 'warning', __( 'No attachments provided', 'trello-social-auto-publisher' ), '' );
+                return rest_ensure_response( $result );
+            }
+
             if ( ! empty( $result['due'] ) ) {
                 $publish_at = sanitize_text_field( $result['due'] );
                 update_post_meta( $post_id, '_tts_publish_at', $publish_at );
@@ -280,9 +288,6 @@ class TTS_Webhook {
                     update_post_meta( $post_id, '_trello_media_ids', $media_ids );
                 }
             }
-
-            $result['post_id']   = $post_id;
-            $result['client_id'] = $client_id;
         }
 
         return rest_ensure_response( $result );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php
@@ -57,10 +57,21 @@ class TTS_Publisher_Facebook {
         );
 
         $attachments = get_attached_media( 'image', $post_id );
+        if ( empty( $attachments ) ) {
+            $manual_id = (int) get_post_meta( $post_id, '_tts_manual_media', true );
+            if ( $manual_id && 0 === strpos( (string) get_post_mime_type( $manual_id ), 'image/' ) ) {
+                $attachments = array( (object) array( 'ID' => $manual_id, 'manual' => true ) );
+            }
+        }
+
         if ( ! empty( $attachments ) ) {
             // Posting an image requires the photos edge and the "pages_manage_posts" permission.
-            $endpoint       = sprintf( 'https://graph.facebook.com/%s/photos', $page_id );
-            $body['source'] = wp_get_attachment_url( reset( $attachments )->ID );
+            $endpoint = sprintf( 'https://graph.facebook.com/%s/photos', $page_id );
+            $url      = wp_get_attachment_url( reset( $attachments )->ID );
+            if ( isset( reset( $attachments )->manual ) ) {
+                $url = wp_make_link_relative( $url );
+            }
+            $body['source'] = $url;
         } else {
             // Text or link posts use the feed edge.
             $endpoint = sprintf( 'https://graph.facebook.com/%s/feed', $page_id );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php
@@ -57,6 +57,18 @@ class TTS_Publisher_Instagram {
         }
 
         if ( empty( $image_url ) && empty( $video_url ) ) {
+            $manual_id = (int) get_post_meta( $post_id, '_tts_manual_media', true );
+            if ( $manual_id ) {
+                $mime = get_post_mime_type( $manual_id );
+                if ( $mime && 0 === strpos( $mime, 'image/' ) ) {
+                    $image_url = wp_make_link_relative( wp_get_attachment_url( $manual_id ) );
+                } elseif ( $mime && 0 === strpos( $mime, 'video/' ) ) {
+                    $video_url = wp_make_link_relative( wp_get_attachment_url( $manual_id ) );
+                }
+            }
+        }
+
+        if ( empty( $image_url ) && empty( $video_url ) ) {
             $error = __( 'No image or video to publish', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'instagram', 'error', $error, '' );
             tts_notify_publication( $post_id, 'error', 'instagram' );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-tiktok.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-tiktok.php
@@ -35,6 +35,13 @@ class TTS_Publisher_TikTok {
 
         $videos = get_attached_media( 'video', $post_id );
         if ( empty( $videos ) ) {
+            $manual_id = (int) get_post_meta( $post_id, '_tts_manual_media', true );
+            if ( $manual_id && 0 === strpos( (string) get_post_mime_type( $manual_id ), 'video/' ) ) {
+                $videos = array( (object) array( 'ID' => $manual_id ) );
+            }
+        }
+
+        if ( empty( $videos ) ) {
             $error = __( 'No video to publish', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'tiktok', 'error', $error, '' );
             tts_notify_publication( $post_id, 'error', 'tiktok' );

--- a/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-youtube.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-youtube.php
@@ -77,6 +77,13 @@ class TTS_Publisher_YouTube {
 
         $videos = get_attached_media( 'video', $post_id );
         if ( empty( $videos ) ) {
+            $manual_id = (int) get_post_meta( $post_id, '_tts_manual_media', true );
+            if ( $manual_id && 0 === strpos( (string) get_post_mime_type( $manual_id ), 'video/' ) ) {
+                $videos = array( (object) array( 'ID' => $manual_id ) );
+            }
+        }
+
+        if ( empty( $videos ) ) {
             $error = __( 'No video to publish', 'trello-social-auto-publisher' );
             tts_log_event( $post_id, 'youtube', 'error', $error, '' );
             tts_notify_publication( $post_id, 'error', 'youtube' );


### PR DESCRIPTION
## Summary
- add Media metabox to social posts that allows selecting/uploading files
- load media selector script in admin
- use manually selected media in all publishers and warn when webhook data lacks attachments

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-facebook.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-instagram.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-youtube.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/publishers/class-tts-publisher-tiktok.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-webhook.php`
- `node --check wp-content/plugins/trello-social-auto-publisher/admin/js/tts-media.js`


------
https://chatgpt.com/codex/tasks/task_e_68c1d764c124832f90a8a0122be0cd82