### PR TITLE
Add scheduled token refresh for clients

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-token-refresh.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-token-refresh.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Token refresh utilities.
+ *
+ * @package TrelloSocialAutoPublisher
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Handles refreshing of social tokens for clients.
+ */
+class TTS_Token_Refresh {
+
+    /**
+     * Refresh tokens for all tts_client posts.
+     */
+    public static function refresh_tokens() {
+        $clients = get_posts(
+            array(
+                'post_type'      => 'tts_client',
+                'posts_per_page' => -1,
+                'post_status'    => 'any',
+            )
+        );
+
+        if ( empty( $clients ) ) {
+            return;
+        }
+
+        foreach ( $clients as $client ) {
+            self::refresh_client_tokens( $client->ID );
+        }
+    }
+
+    /**
+     * Refresh tokens for a single client.
+     *
+     * @param int $client_id Client post ID.
+     */
+    protected static function refresh_client_tokens( $client_id ) {
+        $tokens = array(
+            'facebook'  => array(
+                'meta'  => '_tts_fb_token',
+                'token' => get_post_meta( $client_id, '_tts_fb_token', true ),
+            ),
+            'instagram' => array(
+                'meta'  => '_tts_ig_token',
+                'token' => get_post_meta( $client_id, '_tts_ig_token', true ),
+            ),
+        );
+
+        foreach ( $tokens as $channel => $data ) {
+            $token    = $data['token'];
+            $meta_key = $data['meta'];
+
+            if ( empty( $token ) ) {
+                continue;
+            }
+
+            $grant    = 'facebook' === $channel ? 'fb_exchange_token' : 'ig_refresh_token';
+            $endpoint = 'https://graph.facebook.com/v18.0/refresh_access_token';
+            $url      = add_query_arg(
+                array(
+                    'grant_type'   => $grant,
+                    'access_token' => $token,
+                ),
+                $endpoint
+            );
+
+            $response = wp_remote_get( $url );
+            if ( is_wp_error( $response ) ) {
+                tts_log_event( $client_id, $channel, 'error', 'Token refresh failed', $response->get_error_message() );
+                continue;
+            }
+
+            $body = json_decode( wp_remote_retrieve_body( $response ), true );
+            if ( isset( $body['access_token'] ) ) {
+                update_post_meta( $client_id, $meta_key, sanitize_text_field( $body['access_token'] ) );
+            } else {
+                tts_log_event( $client_id, $channel, 'error', 'Token refresh error', $body );
+            }
+        }
+    }
+}

--- a/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
+++ b/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
@@ -43,3 +43,30 @@ if ( is_admin() ) {
     require_once TSAP_PLUGIN_DIR . 'admin/class-tts-admin.php';
     require_once TSAP_PLUGIN_DIR . 'admin/class-tts-log-page.php';
 }
+
+// Add a weekly cron schedule.
+add_filter(
+    'cron_schedules',
+    function( $schedules ) {
+        if ( ! isset( $schedules['weekly'] ) ) {
+            $schedules['weekly'] = array(
+                'interval' => WEEK_IN_SECONDS,
+                'display'  => __( 'Once Weekly', 'trello-social-auto-publisher' ),
+            );
+        }
+        return $schedules;
+    }
+);
+
+// Schedule weekly token refreshes.
+add_action(
+    'init',
+    function () {
+        if ( ! wp_next_scheduled( 'tts_refresh_tokens' ) ) {
+            wp_schedule_event( time(), 'weekly', 'tts_refresh_tokens' );
+        }
+    }
+);
+
+// Attach the refresh action to the token refresh handler.
+add_action( 'tts_refresh_tokens', array( 'TTS_Token_Refresh', 'refresh_tokens' ) );


### PR DESCRIPTION
## Summary
- add `TTS_Token_Refresh` class to refresh Facebook/Instagram tokens via Graph API and log errors
- schedule weekly cron event and hook to token refresh handler

## Testing
- `php -l includes/class-tts-token-refresh.php`
- `php -l trello-social-auto-publisher.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1d87f5068832f81dca2f4995e15df