### PR TITLE
Aggiunge widget Social Post programmati alla dashboard

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-dashboard-widget.js
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/js/tts-dashboard-widget.js
@@ -1,0 +1,8 @@
+(function($){
+    $(function(){
+        $('#tts-dashboard-widget-refresh').on('click', function(e){
+            e.preventDefault();
+            // Placeholder for AJAX refresh logic.
+        });
+    });
+})(jQuery);


### PR DESCRIPTION
## Summary
- Aggiunta registrazione di un widget "Social Post programmati" con elenco dei post pianificati
- Inserito script JS per il widget per futuri refresh via AJAX

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/admin/class-tts-admin.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1d98ed474832f8b4e460ec03070ad