### PR TITLE
feat: add per-channel custom messages

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php
@@ -134,7 +134,12 @@ class TTS_Scheduler {
                     $publisher   = new $class();
                     $credentials = isset( $tokens[ $ch ] ) ? $tokens[ $ch ] : '';
                     $template    = isset( $options[ $ch . '_template' ] ) ? $options[ $ch . '_template' ] : '';
-                    $message     = $template ? tts_apply_template( $template, $post_id, $ch ) : '';
+                    $custom_message = get_post_meta( $post_id, '_tts_message_' . $ch, true );
+                    if ( $custom_message ) {
+                        $message = $custom_message;
+                    } else {
+                        $message = $template ? tts_apply_template( $template, $post_id, $ch ) : '';
+                    }
 
                     try {
                         $log[ $ch ] = $publisher->publish( $post_id, $credentials, $message );


### PR DESCRIPTION
## Summary
- add "Messaggi per canale" meta box with custom messages for Facebook, Instagram, YouTube and TikTok
- store and expose per-channel messages and use them if available

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-cpt.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-scheduler.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1dccb5164832f89babe506bd8a3a0