### PR TITLE
Add option to convert Trello labels to hashtags

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
@@ -169,6 +169,14 @@ class TTS_Settings {
             'tts_template_options'
         );
 
+        add_settings_field(
+            'labels_as_hashtags',
+            __( 'Labels as Hashtags', 'trello-social-auto-publisher' ),
+            array( $this, 'render_labels_as_hashtags_field' ),
+            'tts_settings',
+            'tts_template_options'
+        );
+
         // Logging options.
         add_settings_section(
             'tts_logging_options',
@@ -295,6 +303,15 @@ class TTS_Settings {
     }
 
     /**
+     * Render field for labels-as-hashtags option.
+     */
+    public function render_labels_as_hashtags_field() {
+        $options = get_option( 'tts_settings', array() );
+        $checked = ! empty( $options['labels_as_hashtags'] );
+        echo '<label><input type="checkbox" name="tts_settings[labels_as_hashtags]" value="1"' . checked( $checked, true, false ) . ' /> ' . esc_html__( 'Append Trello labels as hashtags', 'trello-social-auto-publisher' ) . '</label>';
+    }
+
+    /**
      * Render field for log retention period.
      */
     public function render_log_retention_days_field() {
@@ -337,6 +354,8 @@ function tts_sanitize_settings( $input ) {
     if ( isset( $input['log_retention_days'] ) ) {
         $output['log_retention_days'] = absint( $input['log_retention_days'] );
     }
+
+    $output['labels_as_hashtags'] = ! empty( $input['labels_as_hashtags'] ) ? 1 : 0;
 
     foreach ( $input as $key => $value ) {
         if ( preg_match( '/_utm_/', $key ) ) {

--- a/wp-content/plugins/trello-social-auto-publisher/includes/tts-template.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/tts-template.php
@@ -48,19 +48,22 @@ function tts_apply_template( $template, $post_id, $channel ) {
         return $template;
     }
 
+    $options            = get_option( 'tts_settings', array() );
+    $labels_as_hashtags = ! empty( $options['labels_as_hashtags'] );
+
     $url = get_permalink( $post_id );
     $url = tts_build_utm_url( $url, $channel );
-    $due    = get_post_meta( $post_id, '_trello_due', true );
-    $labels = get_post_meta( $post_id, '_trello_labels', true );
-    if ( is_array( $labels ) ) {
-        $label_names = array();
-        foreach ( $labels as $label ) {
+    $due         = get_post_meta( $post_id, '_trello_due', true );
+    $labels_meta = get_post_meta( $post_id, '_trello_labels', true );
+    $label_names = array();
+    if ( is_array( $labels_meta ) ) {
+        foreach ( $labels_meta as $label ) {
             if ( is_array( $label ) && ! empty( $label['name'] ) ) {
                 $label_names[] = $label['name'];
             }
         }
-        $labels = implode( ', ', $label_names );
     }
+    $labels = implode( ', ', $label_names );
 
     $client_id   = get_post_meta( $post_id, '_tts_client_id', true );
     $client_name = $client_id ? get_the_title( $client_id ) : '';
@@ -71,12 +74,28 @@ function tts_apply_template( $template, $post_id, $channel ) {
         '{excerpt}'     => get_the_excerpt( $post_id ),
         '{url}'         => $url,
         '{due}'         => $due,
-        '{labels}'      => $labels,
+        '{labels}'      => $labels_as_hashtags ? '' : $labels,
         '{client_name}' => $client_name,
         '{publish_at}'  => get_post_meta( $post_id, '_tts_publish_at', true ),
         '{trello_id}'   => get_post_meta( $post_id, '_trello_card_id', true ),
         '{channel}'     => $channel,
     );
 
-    return strtr( $template, $replacements );
+    $message = strtr( $template, $replacements );
+
+    if ( $labels_as_hashtags && ! empty( $label_names ) ) {
+        $hashtags = array();
+        foreach ( $label_names as $label_name ) {
+            $sanitized = sanitize_title( $label_name );
+            $sanitized = str_replace( '-', '', $sanitized );
+            if ( '' !== $sanitized ) {
+                $hashtags[] = '#' . $sanitized;
+            }
+        }
+        if ( ! empty( $hashtags ) ) {
+            $message = trim( $message ) . ' ' . implode( ' ', $hashtags );
+        }
+    }
+
+    return $message;
 }


### PR DESCRIPTION
## Summary
- allow appending sanitized Trello labels as hashtags in templates when enabled
- add checkbox under Template Options to toggle label hashtags and sanitize value

## Testing
- `php -l includes/tts-template.php`
- `php -l includes/class-tts-settings.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1ddb3d420832fbce73096883ce166