### PR TITLE
Add daily social metrics fetching and log columns

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-log-page.php
+++ b/wp-content/plugins/trello-social-auto-publisher/admin/class-tts-log-page.php
@@ -74,6 +74,7 @@ class TTS_Log_Table extends WP_List_Table {
             'channel'    => __( 'Channel', 'trello-social-auto-publisher' ),
             'status'     => __( 'Status', 'trello-social-auto-publisher' ),
             'message'    => __( 'Message', 'trello-social-auto-publisher' ),
+            'metrics'    => __( 'Metrics', 'trello-social-auto-publisher' ),
             'created_at' => __( 'Date', 'trello-social-auto-publisher' ),
         );
     }
@@ -160,6 +161,15 @@ class TTS_Log_Table extends WP_List_Table {
      * @return string
      */
     public function column_default( $item, $column_name ) {
+        if ( 'metrics' === $column_name ) {
+            $metrics = get_post_meta( $item['post_id'], '_tts_metrics', true );
+            $channel = isset( $item['channel'] ) ? $item['channel'] : '';
+            if ( is_array( $metrics ) && isset( $metrics[ $channel ] ) ) {
+                return esc_html( wp_json_encode( $metrics[ $channel ] ) );
+            }
+            return '';
+        }
+
         return isset( $item[ $column_name ] ) ? esc_html( $item[ $column_name ] ) : '';
     }
 

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-analytics.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-analytics.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Fetch social metrics for published posts.
+ *
+ * @package TrelloSocialAutoPublisher
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Analytics utilities.
+ */
+class TTS_Analytics {
+
+    /**
+     * Fetch metrics for all published social posts.
+     */
+    public static function fetch_all() {
+        $posts = get_posts(
+            array(
+                'post_type'      => 'tts_social_post',
+                'posts_per_page' => -1,
+                'post_status'    => 'any',
+                'fields'         => 'ids',
+                'meta_key'       => '_published_status',
+                'meta_value'     => 'published',
+            )
+        );
+
+        foreach ( $posts as $post_id ) {
+            $client_id = (int) get_post_meta( $post_id, '_tts_client_id', true );
+            if ( ! $client_id ) {
+                continue;
+            }
+
+            $tokens = array(
+                'facebook'  => get_post_meta( $client_id, '_tts_fb_token', true ),
+                'instagram' => get_post_meta( $client_id, '_tts_ig_token', true ),
+                'youtube'   => get_post_meta( $client_id, '_tts_yt_token', true ),
+                'tiktok'    => get_post_meta( $client_id, '_tts_tt_token', true ),
+            );
+
+            $channels = get_post_meta( $post_id, '_tts_social_channel', true );
+            $channels = is_array( $channels ) ? $channels : array( $channels );
+
+            $metrics = array();
+            foreach ( $channels as $ch ) {
+                $method = 'fetch_' . $ch . '_metrics';
+                if ( method_exists( __CLASS__, $method ) ) {
+                    $creds = isset( $tokens[ $ch ] ) ? $tokens[ $ch ] : '';
+                    $result = self::$method( $post_id, $creds );
+                    if ( ! is_wp_error( $result ) ) {
+                        $metrics[ $ch ] = $result;
+                    }
+                }
+            }
+
+            if ( ! empty( $metrics ) ) {
+                update_post_meta( $post_id, '_tts_metrics', $metrics );
+            }
+        }
+    }
+
+    /**
+     * Fetch Facebook metrics.
+     *
+     * @param int   $post_id     Post ID.
+     * @param mixed $credentials Access token.
+     *
+     * @return array|WP_Error
+     */
+    public static function fetch_facebook_metrics( $post_id, $credentials ) {
+        if ( empty( $credentials ) ) {
+            return new WP_Error( 'fb_no_token', __( 'Facebook token missing', 'trello-social-auto-publisher' ) );
+        }
+
+        $remote_id = get_post_meta( $post_id, '_tts_facebook_id', true );
+        if ( empty( $remote_id ) ) {
+            return new WP_Error( 'fb_no_id', __( 'Missing Facebook post ID', 'trello-social-auto-publisher' ) );
+        }
+
+        $endpoint = sprintf( 'https://graph.facebook.com/%s?fields=engagement&access_token=%s', rawurlencode( $remote_id ), rawurlencode( $credentials ) );
+        $response = wp_remote_get( $endpoint, array( 'timeout' => 20 ) );
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+        return isset( $data['engagement'] ) ? $data['engagement'] : array();
+    }
+
+    /**
+     * Fetch Instagram metrics.
+     *
+     * @param int   $post_id     Post ID.
+     * @param mixed $credentials Access token.
+     *
+     * @return array|WP_Error
+     */
+    public static function fetch_instagram_metrics( $post_id, $credentials ) {
+        if ( empty( $credentials ) ) {
+            return new WP_Error( 'ig_no_token', __( 'Instagram token missing', 'trello-social-auto-publisher' ) );
+        }
+
+        $remote_id = get_post_meta( $post_id, '_tts_instagram_id', true );
+        if ( empty( $remote_id ) ) {
+            return new WP_Error( 'ig_no_id', __( 'Missing Instagram media ID', 'trello-social-auto-publisher' ) );
+        }
+
+        $endpoint = sprintf( 'https://graph.facebook.com/%s?fields=like_count,comments_count&access_token=%s', rawurlencode( $remote_id ), rawurlencode( $credentials ) );
+        $response = wp_remote_get( $endpoint, array( 'timeout' => 20 ) );
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+        return $data;
+    }
+
+    /**
+     * Fetch YouTube metrics.
+     *
+     * @param int   $post_id     Post ID.
+     * @param mixed $credentials API key or access token.
+     *
+     * @return array|WP_Error
+     */
+    public static function fetch_youtube_metrics( $post_id, $credentials ) {
+        if ( empty( $credentials ) ) {
+            return new WP_Error( 'yt_no_token', __( 'YouTube token missing', 'trello-social-auto-publisher' ) );
+        }
+
+        $remote_id = get_post_meta( $post_id, '_tts_youtube_id', true );
+        if ( empty( $remote_id ) ) {
+            return new WP_Error( 'yt_no_id', __( 'Missing YouTube video ID', 'trello-social-auto-publisher' ) );
+        }
+
+        $endpoint = add_query_arg(
+            array(
+                'id'   => $remote_id,
+                'part' => 'statistics',
+                'key'  => $credentials,
+            ),
+            'https://www.googleapis.com/youtube/v3/videos'
+        );
+        $response = wp_remote_get( $endpoint, array( 'timeout' => 20 ) );
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( isset( $data['items'][0]['statistics'] ) ) {
+            return $data['items'][0]['statistics'];
+        }
+        return array();
+    }
+
+    /**
+     * Fetch TikTok metrics.
+     *
+     * @param int   $post_id     Post ID.
+     * @param mixed $credentials Access token.
+     *
+     * @return array|WP_Error
+     */
+    public static function fetch_tiktok_metrics( $post_id, $credentials ) {
+        if ( empty( $credentials ) ) {
+            return new WP_Error( 'tt_no_token', __( 'TikTok token missing', 'trello-social-auto-publisher' ) );
+        }
+
+        $remote_id = get_post_meta( $post_id, '_tts_tiktok_id', true );
+        if ( empty( $remote_id ) ) {
+            return new WP_Error( 'tt_no_id', __( 'Missing TikTok video ID', 'trello-social-auto-publisher' ) );
+        }
+
+        $endpoint = sprintf( 'https://open.tiktokapis.com/v2/video/%s/metrics?access_token=%s', rawurlencode( $remote_id ), rawurlencode( $credentials ) );
+        $response = wp_remote_get( $endpoint, array( 'timeout' => 20 ) );
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $data = json_decode( wp_remote_retrieve_body( $response ), true );
+        return $data;
+    }
+}

--- a/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
+++ b/wp-content/plugins/trello-social-auto-publisher/trello-social-auto-publisher.php
@@ -76,3 +76,16 @@ add_action(
 
 // Attach the refresh action to the token refresh handler.
 add_action( 'tts_refresh_tokens', array( 'TTS_Token_Refresh', 'refresh_tokens' ) );
+
+// Schedule daily metrics fetching.
+add_action(
+    'init',
+    function () {
+        if ( ! wp_next_scheduled( 'tts_fetch_metrics' ) ) {
+            wp_schedule_event( time(), 'daily', 'tts_fetch_metrics' );
+        }
+    }
+);
+
+// Hook the analytics fetcher.
+add_action( 'tts_fetch_metrics', array( 'TTS_Analytics', 'fetch_all' ) );


### PR DESCRIPTION
## Summary
- Add `TTS_Analytics` class to gather social metrics and store in `_tts_metrics`
- Schedule daily cron `tts_fetch_metrics` and hook into analytics fetcher
- Display stored metrics in Log admin page via new column

## Testing
- `php -l includes/class-tts-analytics.php`
- `php -l admin/class-tts-log-page.php`
- `php -l trello-social-auto-publisher.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1defd9328832fbf20ad8472ad234f