### PR TITLE
Add URL shortener options including Bitly support

### DIFF
--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php
@@ -177,6 +177,30 @@ class TTS_Settings {
             'tts_template_options'
         );
 
+        // URL shortener options.
+        add_settings_section(
+            'tts_url_shortener',
+            __( 'URL Shortener', 'trello-social-auto-publisher' ),
+            '__return_false',
+            'tts_settings'
+        );
+
+        add_settings_field(
+            'url_shortener',
+            __( 'URL Shortener', 'trello-social-auto-publisher' ),
+            array( $this, 'render_url_shortener_field' ),
+            'tts_settings',
+            'tts_url_shortener'
+        );
+
+        add_settings_field(
+            'bitly_token',
+            __( 'Bitly Token', 'trello-social-auto-publisher' ),
+            array( $this, 'render_bitly_token_field' ),
+            'tts_settings',
+            'tts_url_shortener'
+        );
+
         // Logging options.
         add_settings_section(
             'tts_logging_options',
@@ -312,6 +336,36 @@ class TTS_Settings {
     }
 
     /**
+     * Render the URL shortener select field.
+     */
+    public function render_url_shortener_field() {
+        $options = get_option( 'tts_settings', array() );
+        $value   = isset( $options['url_shortener'] ) ? $options['url_shortener'] : 'none';
+
+        $choices = array(
+            'none'  => __( 'None', 'trello-social-auto-publisher' ),
+            'wp'    => __( 'WordPress', 'trello-social-auto-publisher' ),
+            'bitly' => __( 'Bitly', 'trello-social-auto-publisher' ),
+        );
+
+        echo '<select name="tts_settings[url_shortener]">';
+        foreach ( $choices as $key => $label ) {
+            echo '<option value="' . esc_attr( $key ) . '"' . selected( $value, $key, false ) . '>' . esc_html( $label ) . '</option>';
+        }
+        echo '</select>';
+    }
+
+    /**
+     * Render field for Bitly token.
+     */
+    public function render_bitly_token_field() {
+        $options = get_option( 'tts_settings', array() );
+        $value   = isset( $options['bitly_token'] ) ? esc_attr( $options['bitly_token'] ) : '';
+        echo '<input type="text" name="tts_settings[bitly_token]" value="' . $value . '" class="regular-text" />';
+        echo '<p class="description">' . esc_html__( 'Required for Bitly shortening.', 'trello-social-auto-publisher' ) . '</p>';
+    }
+
+    /**
      * Render field for log retention period.
      */
     public function render_log_retention_days_field() {
@@ -334,7 +388,7 @@ function tts_sanitize_settings( $input ) {
         return $output;
     }
 
-    $text_keys = array( 'trello_api_key', 'trello_api_token', 'social_access_token' );
+    $text_keys = array( 'trello_api_key', 'trello_api_token', 'social_access_token', 'bitly_token' );
 
     foreach ( $text_keys as $key ) {
         if ( isset( $input[ $key ] ) ) {
@@ -353,6 +407,12 @@ function tts_sanitize_settings( $input ) {
 
     if ( isset( $input['log_retention_days'] ) ) {
         $output['log_retention_days'] = absint( $input['log_retention_days'] );
+    }
+
+    if ( isset( $input['url_shortener'] ) && in_array( $input['url_shortener'], array( 'none', 'wp', 'bitly' ), true ) ) {
+        $output['url_shortener'] = $input['url_shortener'];
+    } else {
+        $output['url_shortener'] = 'none';
     }
 
     $output['labels_as_hashtags'] = ! empty( $input['labels_as_hashtags'] ) ? 1 : 0;

--- a/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-shortener.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/class-tts-shortener.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * URL shortening utilities.
+ *
+ * @package TrelloSocialAutoPublisher
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Provides methods for shortening URLs.
+ */
+class TTS_Shortener {
+
+    /**
+     * Get the WordPress shortlink for a post.
+     *
+     * @param int $post_id Post ID.
+     * @return string|false Short URL or false on failure.
+     */
+    public static function shorten_wp( $post_id ) {
+        return wp_get_shortlink( $post_id );
+    }
+
+    /**
+     * Shorten a URL using the Bitly API.
+     *
+     * @param string $url   Long URL.
+     * @param string $token Bitly generic access token.
+     * @return string Shortened URL or original URL on failure.
+     */
+    public static function shorten_bitly( $url, $token ) {
+        $response = wp_remote_post(
+            'https://api-ssl.bitly.com/v4/shorten',
+            array(
+                'headers' => array(
+                    'Authorization' => 'Bearer ' . $token,
+                    'Content-Type'  => 'application/json',
+                ),
+                'body'    => wp_json_encode( array( 'long_url' => $url ) ),
+                'timeout' => 10,
+            )
+        );
+
+        if ( is_wp_error( $response ) ) {
+            return $url;
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+        if ( 201 !== $code ) {
+            return $url;
+        }
+
+        $body = json_decode( wp_remote_retrieve_body( $response ), true );
+        if ( isset( $body['link'] ) ) {
+            return $body['link'];
+        }
+
+        return $url;
+    }
+}

--- a/wp-content/plugins/trello-social-auto-publisher/includes/tts-template.php
+++ b/wp-content/plugins/trello-social-auto-publisher/includes/tts-template.php
@@ -53,6 +53,17 @@ function tts_apply_template( $template, $post_id, $channel ) {
 
     $url = get_permalink( $post_id );
     $url = tts_build_utm_url( $url, $channel );
+
+    if ( ! empty( $options['url_shortener'] ) && 'none' !== $options['url_shortener'] ) {
+        if ( 'wp' === $options['url_shortener'] ) {
+            $short = TTS_Shortener::shorten_wp( $post_id );
+            if ( $short ) {
+                $url = $short;
+            }
+        } elseif ( 'bitly' === $options['url_shortener'] && ! empty( $options['bitly_token'] ) ) {
+            $url = TTS_Shortener::shorten_bitly( $url, $options['bitly_token'] );
+        }
+    }
     $due         = get_post_meta( $post_id, '_trello_due', true );
     $labels_meta = get_post_meta( $post_id, '_trello_labels', true );
     $label_names = array();


### PR DESCRIPTION
## Summary
- add TTS_Shortener class for WordPress and Bitly shortening
- expose URL shortener settings and Bitly token input
- apply selected shortener when populating `{url}` placeholder

## Testing
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-shortener.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/class-tts-settings.php`
- `php -l wp-content/plugins/trello-social-auto-publisher/includes/tts-template.php`


------
https://chatgpt.com/codex/tasks/task_e_68c1e09eefc8832f949b8843c7b17447